### PR TITLE
Support for pydantic's defaults in attributes and elements

### DIFF
--- a/pydantic_xml/serializers.py
+++ b/pydantic_xml/serializers.py
@@ -222,6 +222,7 @@ class PrimitiveTypeSerializerFactory:
             nsmap = ctx.parent_nsmap
 
             self.attr_name = QName.from_alias(tag=name, ns=ns, nsmap=nsmap, is_attr=True).uri
+            self.get_default = model_field.get_default
 
         def serialize(
                 self, element: etree.Element, value: Any, *, encoder: XmlEncoder, skip_empty: bool = False,
@@ -235,7 +236,7 @@ class PrimitiveTypeSerializerFactory:
             return element
 
         def deserialize(self, element: etree.Element) -> Optional[str]:
-            return element.get(self.attr_name)
+            return element.get(self.attr_name, self.get_default())
 
     class ElementSerializer(Serializer):
         def __init__(self, model_field: pd.fields.ModelField, ctx: Serializer.Context):
@@ -243,6 +244,7 @@ class PrimitiveTypeSerializerFactory:
             ns = ctx.entity_ns or ctx.parent_ns
             nsmap = merge_nsmaps(ctx.entity_nsmap, ctx.parent_nsmap)
             self.element_name = QName.from_alias(tag=name, ns=ns, nsmap=nsmap).uri
+            self.get_default = model_field.get_default
 
         def serialize(
                 self, element: etree.Element, value: Any, *, encoder: XmlEncoder, skip_empty: bool = False,
@@ -259,7 +261,7 @@ class PrimitiveTypeSerializerFactory:
             return sub_element
 
         def deserialize(self, element: etree.Element) -> Any:
-            return element.findtext(self.element_name)
+            return element.findtext(self.element_name, self.get_default())
 
     @classmethod
     def build(

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -90,3 +90,18 @@ def test_recursive_models():
 
     actual_xml = obj.to_xml(skip_empty=True)
     assert_xml_equal(actual_xml, xml.encode())
+
+
+def test_defaults():
+    class TestModel(BaseXmlModel, tag='model'):
+        attr1: int = attr(default=1)
+        element1: int = element(default=1)
+
+    xml = '<model/>'
+    actual_obj: TestModel = TestModel.from_xml(xml)
+    expected_obj: TestModel = TestModel()
+    assert actual_obj == expected_obj
+
+    expected_xml = '<model attr1="1"><element1>1</element1></model>'
+    actual_xml = actual_obj.to_xml(skip_empty=True)
+    assert_xml_equal(actual_xml, expected_xml.encode())


### PR DESCRIPTION
Fixes #15 

Only deserialization was changed. I don't think, that changing serialization is required here, since these are meant to be pydantic defaults, for the models only. I also added a test that checks this behaviour