### PR TITLE
field default values support added.

### DIFF
--- a/pydantic_xml/model.py
+++ b/pydantic_xml/model.py
@@ -100,6 +100,11 @@ class XmlWrapperInfo(XmlEntityInfo):
             nsmap: Optional[NsMap] = None,
             **kwargs: Any,
     ):
+        if entity is not None:
+            # copy arguments from the wrapped entity to let pydantic know how to process the field
+            for entity_field_name in entity.__slots__:
+                kwargs[entity_field_name] = getattr(entity, entity_field_name)
+
         super().__init__(**kwargs)
         self._entity = entity
         self._path = path

--- a/pydantic_xml/serializers.py
+++ b/pydantic_xml/serializers.py
@@ -210,7 +210,7 @@ class PrimitiveTypeSerializerFactory:
             return element
 
         def deserialize(self, element: etree.Element) -> Optional[str]:
-            return element.text
+            return element.text or None
 
     class AttributeSerializer(Serializer):
         def __init__(
@@ -322,8 +322,9 @@ class ModelSerializerFactory:
 
         def deserialize(self, element: etree.Element) -> Any:
             result = {
-                field_name: field_serializer.deserialize(element)
+                field_name: field_value
                 for field_name, field_serializer in self.field_serializers.items()
+                if (field_value := field_serializer.deserialize(element)) is not None
             }
             if self.is_root:
                 return result['__root__']

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -90,3 +90,43 @@ def test_recursive_models():
 
     actual_xml = obj.to_xml(skip_empty=True)
     assert_xml_equal(actual_xml, xml.encode())
+
+
+def test_defaults():
+    class TestModel(BaseXmlModel, tag='model'):
+        attr1: int = attr(default=1)
+        element1: int = element(default=1)
+        text: str = 'text'
+        attrs: Dict[str, str] = element(tag='model2', default={'key': 'value'})
+        element2: int = wrapped('wrapper', element(tag='model3', default=2))
+
+    xml = '<model/>'
+    actual_obj: TestModel = TestModel.from_xml(xml)
+    expected_obj: TestModel = TestModel()
+    assert actual_obj == expected_obj
+
+    expected_xml = '''
+        <model attr1="1">text<element1>1</element1><model2 key="value"/><wrapper><model3>2</model3></wrapper></model>
+    '''
+    actual_xml = actual_obj.to_xml(skip_empty=True)
+    assert_xml_equal(actual_xml, expected_xml.encode())
+
+
+def test_default_factory():
+    class TestModel(BaseXmlModel, tag='model'):
+        attr1: int = attr(default_factory=lambda: 1)
+        element1: int = element(default_factory=lambda: 1)
+        text: str = 'text'
+        attrs: Dict[str, str] = element(tag='model2', default_factory=lambda: {'key': 'value'})
+        element2: int = wrapped('wrapper', element(tag='model3', default_factory=lambda: 2))
+
+    xml = '<model/>'
+    actual_obj: TestModel = TestModel.from_xml(xml)
+    expected_obj: TestModel = TestModel()
+    assert actual_obj == expected_obj
+
+    expected_xml = '''
+        <model attr1="1">text<element1>1</element1><model2 key="value"/><wrapper><model3>2</model3></wrapper></model>
+    '''
+    actual_xml = actual_obj.to_xml(skip_empty=True)
+    assert_xml_equal(actual_xml, expected_xml.encode())


### PR DESCRIPTION
fixes https://github.com/dapper91/pydantic-xml/issues/15

- adds support of pydantic `default` argument.
- adds support of pydantic `default_factory` argument.

This feature is implemented for primitive attributes and elements, text fields, element mappings, wrapped elements.