### PR TITLE
distutils dependency removed

### DIFF
--- a/pydantic_xml/config.py
+++ b/pydantic_xml/config.py
@@ -1,5 +1,19 @@
-import distutils.util
 import os
 
-REGISTER_NS_PREFIXES = distutils.util.strtobool(os.environ.get('REGISTER_NS_PREFIXES', 'true'))
-FORCE_STD_XML = distutils.util.strtobool(os.environ.get('FORCE_STD_XML', 'false'))
+
+def strtobool(val: str) -> bool:
+    """
+    Converts a string representation of boolean type to true or false.
+    """
+
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return True
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return False
+    else:
+        raise ValueError
+
+
+REGISTER_NS_PREFIXES = strtobool(os.environ.get('REGISTER_NS_PREFIXES', 'true'))
+FORCE_STD_XML = strtobool(os.environ.get('FORCE_STD_XML', 'false'))


### PR DESCRIPTION
distutils dependency removed because it is slated for removal in python 3.12. Fixes https://github.com/dapper91/pydantic-xml/issues/26