### PR TITLE
default namespace redefinition fix

### DIFF
--- a/pydantic_xml/backend.py
+++ b/pydantic_xml/backend.py
@@ -1,9 +1,0 @@
-from . import config
-
-if config.FORCE_STD_XML:
-    import xml.etree.ElementTree as etree
-else:
-    try:
-        from lxml import etree  # type: ignore[no-redef]
-    except ImportError:
-        import xml.etree.ElementTree as etree  # noqa: F401

--- a/pydantic_xml/backend/__init__.py
+++ b/pydantic_xml/backend/__init__.py
@@ -1,0 +1,9 @@
+from pydantic_xml import config
+
+if config.FORCE_STD_XML:
+    from .std import *  # noqa: F403
+else:
+    try:
+        from .lxml import *  # type: ignore[no-redef]  # noqa: F403
+    except ImportError:
+        from .std import *  # noqa: F403

--- a/pydantic_xml/backend/lxml.py
+++ b/pydantic_xml/backend/lxml.py
@@ -1,0 +1,25 @@
+import typing
+import xml.etree.ElementTree as std_etree
+from typing import Any, Dict, Optional
+
+from lxml import etree
+
+__all__ = (
+    'etree',
+    'create_element',
+)
+
+
+def create_element(
+        tag: str,
+        attrib: Optional[Dict[str, Any]] = None,
+        nsmap: Optional[Dict[str, str]] = None,
+) -> std_etree.Element:
+    element = etree.Element(
+        tag,
+        attrib=attrib,
+        # https://github.com/lxml/lxml-stubs/issues/76
+        nsmap={ns or None: uri for ns, uri in nsmap.items()} if nsmap else None,  # type: ignore[misc]
+    )
+
+    return typing.cast(std_etree.Element, element)  # lxml Element copies xml.etree.Element interface

--- a/pydantic_xml/backend/std.py
+++ b/pydantic_xml/backend/std.py
@@ -1,0 +1,15 @@
+import xml.etree.ElementTree as etree
+from typing import Any, Dict, Optional
+
+__all__ = (
+    'etree',
+    'create_element',
+)
+
+
+def create_element(
+        tag: str,
+        attrib: Optional[Dict[str, Any]] = None,
+        nsmap: Optional[Dict[str, str]] = None,  # not supported by `xml.etree`
+) -> etree.Element:
+    return etree.Element(tag, attrib=attrib or {})

--- a/pydantic_xml/model.py
+++ b/pydantic_xml/model.py
@@ -260,9 +260,6 @@ class BaseXmlModel(pd.BaseModel, metaclass=XmlModelMeta):
         root = self.__xml_serializer__.serialize(None, self, encoder=encoder, skip_empty=skip_empty)
         assert root is not None
 
-        if self.__xml_nsmap__ and (default_ns := self.__xml_nsmap__.get('')):
-            root.set('xmlns', default_ns)
-
         return root
 
     def to_xml(

--- a/pydantic_xml/serializers.py
+++ b/pydantic_xml/serializers.py
@@ -13,7 +13,7 @@ import pydantic as pd
 import pydantic_xml as pxml
 from pydantic_xml import errors
 
-from .backend import etree
+from .backend import create_element, etree
 from .utils import NsMap, QName, merge_nsmaps
 
 
@@ -311,6 +311,7 @@ class ModelSerializerFactory:
                 parent_is_root=is_root,
             )
 
+            self.nsmap = nsmap
             self.is_root = is_root
             self.element_name = QName.from_alias(tag=name, ns=ns, nsmap=nsmap).uri
             self.field_serializers = {
@@ -325,7 +326,7 @@ class ModelSerializerFactory:
                 return None
 
             if element is None:
-                element = etree.Element(self.element_name)
+                element = create_element(self.element_name, nsmap=self.nsmap)
 
             for field_name, field_serializer in self.field_serializers.items():
                 field_serializer.serialize(element, getattr(value, field_name), encoder=encoder, skip_empty=skip_empty)
@@ -356,6 +357,7 @@ class ModelSerializerFactory:
             ns = ctx.entity_ns or model.__xml_ns__
             nsmap = merge_nsmaps(ctx.entity_nsmap, model.__xml_nsmap__, ctx.parent_nsmap)
 
+            self.nsmap = nsmap
             self.element_name = QName.from_alias(tag=name, ns=ns, nsmap=nsmap).uri
             self.model = model
 
@@ -367,7 +369,7 @@ class ModelSerializerFactory:
             if value is None:
                 return None
 
-            sub_element = etree.Element(self.element_name)
+            sub_element = create_element(self.element_name, nsmap=self.nsmap)
 
             self.model.__xml_serializer__.serialize(sub_element, value, encoder=encoder, skip_empty=skip_empty)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,6 +6,8 @@ import xmldiff.formatting
 import xmldiff.main
 from lxml import etree
 
+from pydantic_xml import backend
+
 
 def assert_xml_equal(
         left: Union[str, bytes],
@@ -28,3 +30,12 @@ def assert_xml_equal(
             assert not diffs, '\n' + '\n'.join(difflib.Differ().compare(left.splitlines(), right.splitlines()))
         else:
             assert not diffs, '\n' + '\n'.join((str(diff) for diff in diffs))
+
+
+def is_lxml_backend() -> bool:
+    try:
+        import lxml.etree
+    except ImportError:
+        return False
+
+    return backend.etree is lxml.etree


### PR DESCRIPTION
adds nsmap argument to lxml etree.Element method to get rid of default namespace redefinition during serialization. https://github.com/dapper91/pydantic-xml/issues/27.