### PR TITLE
Support `xs:list` inline lists

### DIFF
--- a/tests/test_homogeneous_collections.py
+++ b/tests/test_homogeneous_collections.py
@@ -121,6 +121,25 @@ def test_list_of_dicts_extraction():
     assert_xml_equal(actual_xml, xml)
 
 
+def test_text_list_extraction():
+    class RootModel(BaseXmlModel, tag="model"):
+        values: List[int]
+
+    xml = '''
+    <model>1 2 70 -34</model>
+    '''
+
+    actual_obj = RootModel.from_xml(xml)
+    expected_obj = RootModel(
+        values = [1, 2, 70, -34]
+    )
+
+    assert actual_obj == expected_obj
+
+    actual_xml = actual_obj.to_xml()
+    assert_xml_equal(actual_xml, xml)
+
+
 def test_homogeneous_definition_errors():
     with pytest.raises(errors.ModelFieldError):
         class TestModel(BaseXmlModel):

--- a/tests/test_homogeneous_collections.py
+++ b/tests/test_homogeneous_collections.py
@@ -131,10 +131,27 @@ def test_text_list_extraction():
 
     actual_obj = RootModel.from_xml(xml)
     expected_obj = RootModel(
-        values = [1, 2, 70, -34]
+        values=[1, 2, 70, -34]
     )
 
     assert actual_obj == expected_obj
+
+    actual_xml = actual_obj.to_xml()
+    assert_xml_equal(actual_xml, xml)
+
+
+def test_text_tuple_extraction():
+    class RootModel(BaseXmlModel, tag="model"):
+        values: Tuple[int, ...]
+
+    xml = '''
+    <model>1 2 70 -34</model>
+    '''
+
+    actual_obj = RootModel.from_xml(xml)
+    expected_obj = RootModel(
+        values=[1, 2, 70, -34]
+    )
 
     actual_xml = actual_obj.to_xml()
     assert_xml_equal(actual_xml, xml)
@@ -155,7 +172,31 @@ def test_attr_list_extraction():
 
     actual_obj = RootModel.from_xml(xml)
     expected_obj = RootModel(
-        values = [3.14, -1.0, 3e2]
+        values=[3.14, -1.0, 3e2]
+    )
+
+    assert actual_obj == expected_obj
+
+    actual_xml = actual_obj.to_xml()
+    assert_xml_equal(actual_xml, xml)
+
+
+def test_attr_tuple_extraction():
+    class RootModel(BaseXmlModel, tag="model"):
+        values: List[float] = attr()
+
+    xml = '''
+    <model values="3.14 -1.0 300.0"/>
+    '''
+    # This will fail if scientific notation is used
+    # i.e. if 300 is replaced with 3e2 or 300, the deserializer
+    # will always use the standard notation with the added `.0`.
+    # While this behaviour fails the tests, it shouldn't
+    # matter in practice.
+
+    actual_obj = RootModel.from_xml(xml)
+    expected_obj = RootModel(
+        values=[3.14, -1.0, 3e2]
     )
 
     assert actual_obj == expected_obj

--- a/tests/test_homogeneous_collections.py
+++ b/tests/test_homogeneous_collections.py
@@ -175,3 +175,10 @@ def test_homogeneous_definition_errors():
 
         class TestModel(BaseXmlModel):
             __root__: List[TestSubModel]
+
+    with pytest.raises(errors.ModelFieldError):
+        class TestSubModel(BaseXmlModel):
+            attr: int
+
+        class TestModel(BaseXmlModel):
+            text: List[TestSubModel]

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -39,7 +39,7 @@ def test_skip_empty():
 
     class TestModel(BaseXmlModel, tag='model'):
         model: TestSubModel
-        list: List[TestSubModel] = []
+        list: List[TestSubModel] = element(default=[])
         tuple: Optional[Tuple[TestSubModel, TestSubModel]] = None
         attrs: Dict[str, str] = {}
         wrapped: Optional[str] = wrapped('envelope')


### PR DESCRIPTION
Hi!

I started using this package for work and think it's fantastic.
However, some of the features of XML Schema, which are necessary for our uses, are not possible to model with currently.
This PR addresses the schema type `xs:list`, which allows you to create lists of simple types (i.e. a list of whitespace-separated values in the text field).
Using this example from [w3schools](https://www.w3schools.com/xml/el_list.asp):
```xml
<?xml version="1.0"?>
<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">

<xs:element name="intvalues" type="valuelist"/>

<xs:simpleType name="valuelist">
  <xs:list itemType="xs:integer"/>
</xs:simpleType>

</xs:schema>

<!-- The "intvalues" element in a document could look like this
     (notice that the list will have five list items): -->

<intvalues>100 34 56 -23 1567</intvalues>
```
Furthermore, attributes can also be of a `xs:list` type, so
```xml
<model ints="3 2 1"/>
```
is also valid.

These xml objects would be modeled as
```python
from typing import List
from pydantic_xml import XmlBaseModel, attr

class IntValues(XmlBaseModel, tag="intvalues"):
    values: List[int]

class AttrListModel(XmlBaseModel, tag="model"):
    attr_values: List[int] = attr(name="ints")
```

## Current behaviour

The `HomogeneousSerializerFactory` currently throws an error if an attribute is set to a `list[T]` type, and it will create an `ElementSerializer` for the text field.
Thus, the current behaviour looks like this:
```python
from typing import List
from pydantic_xml import XmlBaseModel, attr

class Foo(XmlBaseModel, tag="model"):
    text: List[int]

print(Foo(text=[1, 2, 3]).to_xml(pretty_print=True)))
# Prints
# <model>
#     <text>1</text>
#     <text>2</text>
#     <text>3</text>
# </model>

class Bar(XmlBaseModel, tag="model"):
    ints: List[int] = attr()  # Currently not allowed and throws an error
```

## Proposed changes

Add `TextSerializer` and `AttributeSerializer` classes to the `HomogeneousSerializerFactory` which will work according to the example in the introduction.

## Potential issues

This PR is not backwards compatible with version 0.5.0 in a way that fixes a "bug" IMO. This package seems to be in beta so it shouldn't be that big of a deal, but it's still important to consider.

## Planned actions

If you approve of these changes, I will also update the documentation to reflect these changes. I just didn't want to start doing that before I got an ok.
