### PR TITLE
Fix `bool` serialized as `int`

### DIFF
--- a/pydantic_xml/serializers.py
+++ b/pydantic_xml/serializers.py
@@ -32,10 +32,10 @@ class XmlEncoder:
 
         if isinstance(obj, str):
             return obj
-        if isinstance(obj, (int, float, Decimal)):
-            return str(obj)
         if isinstance(obj, bool):
             return str(obj).lower()
+        if isinstance(obj, (int, float, Decimal)):
+            return str(obj)
         if isinstance(obj, (dt.datetime, dt.date, dt.time)):
             return obj.isoformat()
         if isinstance(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -39,3 +39,22 @@ def test_ipaddress_fields_extraction():
 
     actual_xml = actual_obj.to_xml()
     assert_xml_equal(actual_xml, xml)
+
+
+def test_bool_extraction():
+    class TestModel(BaseXmlModel, tag='model'):
+        text: bool
+
+    xml = '''
+    <model>true</model>
+    '''
+
+    actual_obj = TestModel.from_xml(xml)
+    expected_obj = TestModel(
+        text=True,
+    )
+
+    assert actual_obj == expected_obj
+
+    actual_xml = actual_obj.to_xml()
+    assert_xml_equal(actual_xml, xml)


### PR DESCRIPTION
I'll prefix this PR with that I might well be misunderstanding the design a bit.

Currently, because numbers are serialized before floats in the `XmlEncoder` class, `bool`s are serialized the same as `int`s, i.e. without calling `str(obj).lower()`. This PR changes the order of the checks and adds a test that checks for this bug.