### PR TITLE
piped union typehint support added

### DIFF
--- a/pydantic_xml/serializers/serializer.py
+++ b/pydantic_xml/serializers/serializer.py
@@ -1,9 +1,16 @@
 import abc
 import dataclasses as dc
+import sys
 import typing
 from enum import IntEnum
 from inspect import isclass
 from typing import Any, Dict, Optional, Tuple, Type, Union
+
+if sys.version_info < (3, 10):
+    UnionTypes = (Union,)
+else:
+    from types import UnionType
+    UnionTypes = (Union, UnionType)
 
 import pydantic as pd
 
@@ -67,7 +74,7 @@ def is_xml_model(tp: Any) -> bool:
 
 
 def is_union(type_: Any) -> bool:
-    return typing.get_origin(type_) is Union
+    return typing.get_origin(type_) in UnionTypes
 
 
 def is_optional(type_: Any) -> bool:


### PR DESCRIPTION
Starting from python 3.10 it is possible to describe union types using pipe (X | Y). See https://peps.python.org/pep-0604/.

Therefore this syntax is correct starting from python 3.10 and should be supported by the library:

```python
class Model(BaseXmlModel):
    text: int | float | str
```

Fixes the issue https://github.com/dapper91/pydantic-xml/issues/56.