### PR TITLE
wrapped sub-elements serialization bug fixed

### DIFF
--- a/pydantic_xml/element/element.py
+++ b/pydantic_xml/element/element.py
@@ -257,6 +257,7 @@ class XmlElement(XmlElementReader, XmlElementWriter, Generic[NativeElement]):
 
     def append_element(self, element: 'XmlElement[NativeElement]') -> None:
         self._state.elements.append(element)
+        self._state.next_element_idx += 1
 
     def pop_text(self) -> Optional[str]:
         result, self._state.text = self._state.text, None
@@ -295,6 +296,7 @@ class XmlElement(XmlElementReader, XmlElementWriter, Generic[NativeElement]):
         if (sub_element := self._find_element(tag, search_mode)) is None:
             sub_element = self.make_element(tag=tag, nsmap=nsmap)
             self._state.elements.append(sub_element)
+            self._state.next_element_idx += 1
 
         return sub_element
 

--- a/pydantic_xml/serializers/factories/union.py
+++ b/pydantic_xml/serializers/factories/union.py
@@ -1,3 +1,4 @@
+import dataclasses as dc
 import typing
 from typing import Any, List, Optional, Type
 
@@ -70,7 +71,11 @@ class UnionSerializerFactory:
                     ),
                 )
 
-                serializer = self._build_field_serializer(model, sub_field, ctx)
+                serializer = self._build_field_serializer(
+                    model,
+                    sub_field,
+                    dc.replace(ctx, parent_is_root=False),
+                )
                 assert isinstance(serializer, ModelSerializerFactory.ModelSerializer), "unexpected serializer type"
 
                 inner_serializers.append(serializer)

--- a/tests/test_heterogeneous_collections.py
+++ b/tests/test_heterogeneous_collections.py
@@ -111,6 +111,36 @@ def test_list_of_dict_extraction():
     assert_xml_equal(actual_xml, xml)
 
 
+def test_root_tuple_of_submodels_extraction():
+    class TestSubModel(BaseXmlModel, tag='model2'):
+        text: int
+
+    class TestModel(BaseXmlModel, tag='model1'):
+        __root__: Tuple[TestSubModel, TestSubModel, TestSubModel] = element()
+
+    xml = '''
+    <model1>
+        <model2>1</model2>
+        <model2>2</model2>
+        <model2>3</model2>
+    </model1>
+    '''
+
+    actual_obj = TestModel.from_xml(xml)
+    expected_obj = TestModel(
+        __root__=[
+            TestSubModel(text=1),
+            TestSubModel(text=2),
+            TestSubModel(text=3),
+        ],
+    )
+
+    assert actual_obj == expected_obj
+
+    actual_xml = actual_obj.to_xml()
+    assert_xml_equal(actual_xml, xml)
+
+
 def test_heterogeneous_definition_errors():
     with pytest.raises(errors.ModelFieldError):
         class TestModel(BaseXmlModel):

--- a/tests/test_homogeneous_collections.py
+++ b/tests/test_homogeneous_collections.py
@@ -121,6 +121,36 @@ def test_list_of_dicts_extraction():
     assert_xml_equal(actual_xml, xml)
 
 
+def test_root_list_of_submodels_extraction():
+    class TestSubModel(BaseXmlModel, tag='model2'):
+        text: int
+
+    class TestModel(BaseXmlModel, tag='model1'):
+        __root__: List[TestSubModel] = element()
+
+    xml = '''
+    <model1>
+        <model2>1</model2>
+        <model2>2</model2>
+        <model2>3</model2>
+    </model1>
+    '''
+
+    actual_obj = TestModel.from_xml(xml)
+    expected_obj = TestModel(
+        __root__=[
+            TestSubModel(text=1),
+            TestSubModel(text=2),
+            TestSubModel(text=3),
+        ],
+    )
+
+    assert actual_obj == expected_obj
+
+    actual_xml = actual_obj.to_xml()
+    assert_xml_equal(actual_xml, xml)
+
+
 def test_homogeneous_definition_errors():
     with pytest.raises(errors.ModelFieldError):
         class TestModel(BaseXmlModel):

--- a/tests/test_unions.py
+++ b/tests/test_unions.py
@@ -150,6 +150,31 @@ def test_primitive_union_tuple():
     assert_xml_equal(actual_xml, xml)
 
 
+def test_root_union():
+    class SubModel1(BaseXmlModel, tag='model1'):
+        attr1: int = attr()
+
+    class SubModel2(BaseXmlModel, tag='model2'):
+        element1: float
+
+    class TestModel(BaseXmlModel, tag='model'):
+        __root__: Union[SubModel1, SubModel2]
+
+    xml = '''
+    <model>
+        <model2>inf</model2>
+    </model>
+    '''
+
+    actual_obj = TestModel.from_xml(xml)
+    expected_obj = TestModel(__root__=SubModel2(element1=float('inf')))
+
+    assert actual_obj == expected_obj
+
+    actual_xml = actual_obj.to_xml()
+    assert_xml_equal(actual_xml, xml)
+
+
 def test_submodel_definition_errors():
     with pytest.raises(TypeError):
         class SubModel(BaseXmlModel):

--- a/tests/test_wrapped.py
+++ b/tests/test_wrapped.py
@@ -7,18 +7,54 @@ from pydantic_xml import BaseXmlModel, attr, element, wrapped
 
 def test_wrapped_primitive_extraction():
     class TestModel(BaseXmlModel, tag='model1'):
+        element0: str = element(tag='element')
         data: int = wrapped('model2')
-        attr1: int = wrapped('model2', attr())
+        attr1: int = wrapped('model2', attr(name='attr1'))
         element1: int = wrapped('model2', element())
 
     xml = '''
     <model1>
+        <element>text</element>
         <model2 attr1="2">1<element1>3</element1></model2>
     </model1>
     '''
 
     actual_obj = TestModel.from_xml(xml)
-    expected_obj = TestModel(data=1, attr1=2, element1=3)
+    expected_obj = TestModel(element0="text", data=1, attr1=2, element1=3)
+
+    assert actual_obj == expected_obj
+
+    actual_xml = actual_obj.to_xml()
+    assert_xml_equal(actual_xml, xml)
+
+
+def test_wrapped_path_merge():
+    class TestModel(BaseXmlModel, tag='model1'):
+        element0: int = element(tag='element0')
+        element1: int = element(tag='element1')
+        attr0: int = wrapped('element1', attr(name='attr'))
+        element2: int = wrapped('element2/element3', element(tag='element4'))
+        element3: int = wrapped('element2/element3', element(tag='element5'))
+        attr1: int = wrapped('element2/element6', attr(name='attr'))
+        element4: int = element(tag='element7')
+
+    xml = '''
+    <model1>
+        <element0>0</element0>
+        <element1 attr="2">1</element1>
+        <element2>
+            <element3>
+                <element4>3</element4>
+                <element5>4</element5>
+            </element3>
+            <element6 attr="5"/>
+        </element2>
+        <element7>6</element7>
+    </model1>
+    '''
+
+    actual_obj = TestModel.from_xml(xml)
+    expected_obj = TestModel(element0=0, element1=1, attr0=2, element2=3, element3=4, attr1=5, element4=6)
 
     assert actual_obj == expected_obj
 
@@ -209,6 +245,30 @@ def test_wrapper_element_interleaving():
         element5=5,
         element6=6,
     )
+
+    assert actual_obj == expected_obj
+
+    actual_xml = actual_obj.to_xml()
+    assert_xml_equal(actual_xml, xml)
+
+
+def test_wrapped_root():
+    class TestSubModel(BaseXmlModel, tag='model3'):
+        attr1: int = attr()
+
+    class TestModel(BaseXmlModel, tag='model1'):
+        __root__: TestSubModel = wrapped('model2')
+
+    xml = '''
+    <model1>
+        <model2>
+            <model3 attr1="1"/>
+        </model2>
+    </model1>
+    '''
+
+    actual_obj = TestModel.from_xml(xml)
+    expected_obj = TestModel(__root__=TestSubModel(attr1=1))
 
     assert actual_obj == expected_obj
 


### PR DESCRIPTION
This MR fixes the bug related to wrapped sub-elements serialization. 

The model:

```python
from pydantic_xml import BaseXmlModel, element, wrapped

class Company(BaseXmlModel):
    title: str = element()
    country: str = wrapped('address', element())
    city: str = wrapped('address', element())

model = Company(title='SpaceX', country='US', city='Hawthorne')
```

should be serialized to the xml document:

```xml
<Company>
  <title>SpaceX</title>
  <address>
    <country>US</country>
    <city>Hawthorne</city>
  </address>
</Company>
```

but wrapped element is duplicated:

```xml
<Company>
  <title>SpaceX</title>
  <address>
    <country>US</country>
  </address>
  <address>
    <city>Hawthorne</city>
  </address>
</Company>
```


fixes the issue https://github.com/dapper91/pydantic-xml/issues/63