### PR TITLE
pydantic extra check

### DIFF
--- a/pydantic_xml/element/element.py
+++ b/pydantic_xml/element/element.py
@@ -11,6 +11,13 @@ class XmlElementReader(abc.ABC):
     Provides an interface for extracting element text, attributes and sub-elements.
     """
 
+    @property
+    @abc.abstractmethod
+    def tag(self) -> str:
+        """
+        Xml element tag.
+        """
+
     @abc.abstractmethod
     def is_empty(self) -> bool:
         """
@@ -46,6 +53,14 @@ class XmlElementReader(abc.ABC):
         """
 
     @abc.abstractmethod
+    def get_text(self) -> Optional[str]:
+        """
+        Returns the element text.
+
+        :return: element text
+        """
+
+    @abc.abstractmethod
     def pop_text(self) -> Optional[str]:
         """
         Extracts the text from the xml element.
@@ -61,6 +76,14 @@ class XmlElementReader(abc.ABC):
         All subsequent calls with the same name return `None`.
 
         :return: element attribute
+        """
+
+    @abc.abstractmethod
+    def get_attributes(self) -> Optional[Dict[str, str]]:
+        """
+        Returns the element attributes.
+
+        :return: element attributes
         """
 
     @abc.abstractmethod
@@ -90,6 +113,14 @@ class XmlElementReader(abc.ABC):
         :param path: path the element is searched at
         :param search_mode: element search mode
         :return: found element or `None`
+        """
+
+    @abc.abstractmethod
+    def get_elements(self) -> Optional[List['XmlElement[Any]']]:
+        """
+        Returns the element sub-elements.
+
+        :return: sub-element
         """
 
     @abc.abstractmethod
@@ -306,6 +337,9 @@ class XmlElement(XmlElementReader, XmlElementWriter, Generic[NativeElement]):
     def get_attrib(self, name: str) -> Optional[str]:
         return self._state.attrib.get(name, None) if self._state.attrib else None
 
+    def get_text(self) -> Optional[str]:
+        return self._state.text
+
     def pop_text(self) -> Optional[str]:
         result, self._state.text = self._state.text, None
 
@@ -313,6 +347,9 @@ class XmlElement(XmlElementReader, XmlElementWriter, Generic[NativeElement]):
 
     def pop_attrib(self, name: str) -> Optional[str]:
         return self._state.attrib.pop(name, None) if self._state.attrib else None
+
+    def get_attributes(self) -> Optional[Dict[str, str]]:
+        return self._state.attrib
 
     def pop_attributes(self) -> Optional[Dict[str, str]]:
         result, self._state.attrib = self._state.attrib, None
@@ -357,6 +394,9 @@ class XmlElement(XmlElementReader, XmlElementWriter, Generic[NativeElement]):
         searcher: Searcher[NativeElement] = get_searcher(search_mode)
 
         return searcher(self._state, tag, look_behind, step_forward)
+
+    def get_elements(self) -> Optional[List['XmlElement[NativeElement]']]:
+        return self._state.elements[self._state.next_element_idx:]
 
 
 class SearchMode(str, Enum):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,4 +1,5 @@
 from typing import Dict, List, Optional, Tuple, Union
+from unittest.mock import ANY
 
 import pydantic as pd
 import pytest
@@ -253,3 +254,51 @@ def test_pydantic_validation_context():
     '''
 
     TestModel.from_xml(xml, validation_context)
+
+
+@pytest.mark.parametrize('search_mode', ['strict', 'ordered', 'unordered'])
+def test_extra_forbid(search_mode: str):
+    class Model(BaseXmlModel, tag='model', extra='forbid', search_mode=search_mode):
+        attr1: str = attr()
+        field1: str = element()
+        field2: str = wrapped('wrapper', element())
+
+    xml = '''
+        <model attr1="attr value 1" attr2="attr value 2">text value
+            <field1>field value 1</field1>
+            <wrapper>
+                <field2>field value 2</field2>
+            </wrapper>
+            <field3>field value 3</field3>
+        </model>
+    '''
+
+    with pytest.raises(pd.ValidationError) as exc:
+        Model.from_xml(xml)
+
+    err = exc.value
+    assert err.title == 'Model'
+    assert err.error_count() == 3
+    assert err.errors() == [
+        {
+            'input': 'text value',
+            'loc': ('<text>',),
+            'msg': 'Extra inputs are not permitted',
+            'type': 'extra_forbidden',
+            'url': ANY,
+        },
+        {
+            'input': 'attr value 2',
+            'loc': ('<attr> attr2',),
+            'msg': 'Extra inputs are not permitted',
+            'type': 'extra_forbidden',
+            'url': ANY,
+        },
+        {
+            'input': 'field value 3',
+            'loc': ('<element> field3',),
+            'msg': 'Extra inputs are not permitted',
+            'type': 'extra_forbidden',
+            'url': ANY,
+        },
+    ]


### PR DESCRIPTION
pydantic extra='forbid' parameter is being applied to xml elements too.

Implements the [feauture request](https://github.com/dapper91/pydantic-xml/issues/105).

Code example:
```python
class Model(BaseXmlModel, tag='root', extra='forbid', search_mode=search_mode):
    attr1: str = attr()
    field1: str = element()

xml = '''
    <root attr1="attr value 1" attr2="attr value 2">
        <field1>field value 1</field1>
        <field2>field value 2</field2>
    </root>
'''

try:
    Model.from_xml(xml)
except pd.ValidationError as err:
    assert err.errors() == [
        {
            'type': 'extra_forbidden',
            'msg': 'Extra inputs are not permitted',
            'input': 'attr value 2',
            'loc': ('<attr> attr2',),
        },
        {
            'type': 'extra_forbidden',
            'msg': 'Extra inputs are not permitted',
            'input': 'field value 2',
            'loc': ('<element> field2',),
        },
    ]
```