### PR TITLE
Encoding fix

### DIFF
--- a/docs/source/pages/misc.rst
+++ b/docs/source/pages/misc.rst
@@ -46,10 +46,8 @@ None type encoding
 __________________
 
 Since xml format doesn't support ``null`` type natively it is not obvious how to encode ``None`` fields
-(ignore it, encode it as an empty string or mark it as ``xsi:nil``) the library doesn't implement
-``None`` type encoding by default.
-
-You can define your own encoding format:
+(ignore it, encode it as an empty string or mark it as ``xsi:nil``). The library encodes ``None`` typed fields
+as empty strings by default but you can define your own encoding format:
 
 .. literalinclude:: ../../../examples/snippets/py3.9/serialization.py
   :language: python

--- a/pydantic_xml/serializers/factories/primitive.py
+++ b/pydantic_xml/serializers/factories/primitive.py
@@ -4,7 +4,7 @@ from pydantic_core import core_schema as pcs
 
 from pydantic_xml import errors
 from pydantic_xml.element import XmlElementReader, XmlElementWriter
-from pydantic_xml.serializers.serializer import SearchMode, Serializer
+from pydantic_xml.serializers.serializer import SearchMode, Serializer, encode_primitive
 from pydantic_xml.typedefs import EntityLocation, NsMap
 from pydantic_xml.utils import QName, merge_nsmaps
 
@@ -44,7 +44,7 @@ class TextSerializer(Serializer):
         if value is None and skip_empty:
             return element
 
-        element.set_text(str(encoded))
+        element.set_text(encode_primitive(encoded))
         return element
 
     def deserialize(
@@ -90,7 +90,7 @@ class AttributeSerializer(Serializer):
         if value is None and skip_empty:
             return element
 
-        element.set_attribute(self._attr_name, str(encoded))
+        element.set_attribute(self._attr_name, encode_primitive(encoded))
 
         return element
 

--- a/pydantic_xml/serializers/serializer.py
+++ b/pydantic_xml/serializers/serializer.py
@@ -16,7 +16,9 @@ from . import factories
 
 
 def encode_primitive(value: Any) -> str:
-    if isinstance(value, bool):
+    if value is None:
+        return ''
+    elif isinstance(value, bool):
         return str(value).lower()
     else:
         return str(value)

--- a/pydantic_xml/serializers/serializer.py
+++ b/pydantic_xml/serializers/serializer.py
@@ -15,6 +15,13 @@ from pydantic_xml.typedefs import EntityLocation, NsMap
 from . import factories
 
 
+def encode_primitive(value: Any) -> str:
+    if isinstance(value, bool):
+        return str(value).lower()
+    else:
+        return str(value)
+
+
 class SchemaTypeFamily(IntEnum):
     META = 0
     PRIMITIVE = 1

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -39,7 +39,7 @@ def test_primitive_types_encoding():
     <model>
         <field1>1</field1>
         <field2>1.1</field2>
-        <field3>True</field3>
+        <field3>true</field3>
         <field4>3.14</field4>
         <field5>2023-02-04T12:01:02</field5>
         <field6>2023-02-04</field6>

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -28,7 +28,7 @@ def test_root_generic_model():
     assert_xml_equal(actual_xml, xml1)
 
     xml2 = '''
-    <model1 attr1="True" attr2="string"/>
+    <model1 attr1="true" attr2="string"/>
     '''
 
     TestModel = GenericModel[bool, str]

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -75,7 +75,7 @@ def test_model_level_skip_empty_enable():
     xml = '''
     <model>
         <submodel></submodel>
-        <element1>None</element1>
+        <element1></element1>
     </model>
     '''
 
@@ -104,7 +104,7 @@ def test_model_level_skip_empty_disable():
 
     xml = '''
     <model>
-        <submodel attr1="None">None<element1>None</element1></submodel>
+        <submodel attr1=""><element1></element1></submodel>
     </model>
     '''
 


### PR DESCRIPTION
- bool type encoding format changed from 'True' to 'true'. See https://www.w3.org/TR/xmlschema-2/#boolean.
- None type encoding format changed from 'None' to ''.

fixes https://github.com/dapper91/pydantic-xml/issues/126, https://github.com/dapper91/pydantic-xml/issues/128 issues