### PR TITLE
nillable element support added.

### DIFF
--- a/docs/source/pages/misc.rst
+++ b/docs/source/pages/misc.rst
@@ -42,30 +42,39 @@ The following example illustrate how to encode :py:class:`bytes` typed fields as
     :language: xml
 
 
-None type encoding
-__________________
+Optional type encoding
+~~~~~~~~~~~~~~~~~~~~~~
 
 Since xml format doesn't support ``null`` type natively it is not obvious how to encode ``None`` fields
-(ignore it, encode it as an empty string or mark it as ``xsi:nil``). The library encodes ``None`` typed fields
-as empty strings by default but you can define your own encoding format:
+(ignore it, encode it as an empty string or mark it as ``xsi:nil``).
+The library encodes ``None`` values as empty strings by default.
+There are some alternative ways:
+
+- Define your own encoding format for ``None`` values:
 
 .. literalinclude:: ../../../examples/snippets/py3.9/serialization.py
   :language: python
 
 
-or drop ``None`` fields at all:
+- Mark an empty elements as `nillable <https://www.w3.org/TR/xmlschema-1/#xsi_nil>`_:
+
+.. literalinclude:: ../../../examples/snippets/serialization_nillable.py
+  :language: python
+
+
+- Drop empty elements:
 
 .. code-block:: python
 
     from typing import Optional
     from pydantic_xml import BaseXmlModel, element
 
-    class Company(BaseXmlModel):
+    class Company(BaseXmlModel, skip_empty=True):
         title: Optional[str] = element(default=None)
 
 
     company = Company()
-    assert company.to_xml(skip_empty=True) == b'<Company/>'
+    assert company.to_xml() == b'<Company/>'
 
 
 Empty entities exclusion

--- a/examples/snippets/serialization_nillable.py
+++ b/examples/snippets/serialization_nillable.py
@@ -1,0 +1,20 @@
+from typing import Optional
+from xml.etree.ElementTree import canonicalize
+
+from pydantic_xml import BaseXmlModel, element
+
+
+class Company(BaseXmlModel):
+    title: Optional[str] = element(default=None, nillable=True)
+
+
+xml_doc = '''
+<Company>
+    <title xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+</Company>
+'''
+
+company = Company.from_xml(xml_doc)
+
+assert company.title is None
+assert canonicalize(company.to_xml(), strip_text=True) == canonicalize(xml_doc, strip_text=True)

--- a/pydantic_xml/element/__init__.py
+++ b/pydantic_xml/element/__init__.py
@@ -1,1 +1,2 @@
 from .element import SearchMode, XmlElement, XmlElementReader, XmlElementWriter
+from .utils import is_element_nill, make_element_nill

--- a/pydantic_xml/element/utils.py
+++ b/pydantic_xml/element/utils.py
@@ -1,0 +1,14 @@
+from .element import XmlElementReader, XmlElementWriter
+
+XSI_NS = 'http://www.w3.org/2001/XMLSchema-instance'
+
+
+def is_element_nill(element: XmlElementReader) -> bool:
+    if (is_nil := element.pop_attrib('{%s}nil' % XSI_NS)) and is_nil == 'true':
+        return True
+    else:
+        return False
+
+
+def make_element_nill(element: XmlElementWriter) -> None:
+    element.set_attribute('{%s}nil' % XSI_NS, 'true')

--- a/pydantic_xml/serializers/serializer.py
+++ b/pydantic_xml/serializers/serializer.py
@@ -96,6 +96,7 @@ class XmlEntityInfoP(typing.Protocol):
     path: Optional[str]
     ns: Optional[str]
     nsmap: Optional[NsMap]
+    nillable: bool
     wrapped: Optional['XmlEntityInfoP']
 
 
@@ -136,6 +137,10 @@ class Serializer(abc.ABC):
         @property
         def entity_nsmap(self) -> Optional[NsMap]:
             return self.entity_info.nsmap if self.entity_info is not None else None
+
+        @property
+        def nillable(self) -> bool:
+            return self.entity_info.nillable if self.entity_info is not None else False
 
         @property
         def entity_wrapped(self) -> Optional['XmlEntityInfoP']:

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from helpers import assert_xml_equal
 from pydantic import computed_field
 
@@ -63,6 +65,29 @@ def test_computed_elements():
     assert_xml_equal(actual_xml, xml)
 
 
+def test_computed_nillable_elements():
+    class TestModel(BaseXmlModel, tag='model'):
+        @computed_element(tag='element1', nillable=True)
+        def computed_element1(self) -> Optional[int]:
+            return None
+
+        @computed_element(tag='element2', nillable=True)
+        def computed_element2(self) -> Optional[int]:
+            return 2
+
+    xml = '''
+    <model>
+        <element1 xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+        <element2>2</element2>
+    </model>
+    '''
+
+    actual_obj = TestModel.from_xml(xml)
+
+    actual_xml = actual_obj.to_xml()
+    assert_xml_equal(actual_xml, xml)
+
+
 def test_computed_submodel():
     class TestSumModel(BaseXmlModel):
         text: str
@@ -80,6 +105,27 @@ def test_computed_submodel():
     <model>
         <submodel1>text1</submodel1>
         <submodel2>text2</submodel2>
+    </model>
+    '''
+
+    actual_obj = TestModel.from_xml(xml)
+
+    actual_xml = actual_obj.to_xml()
+    assert_xml_equal(actual_xml, xml)
+
+
+def test_computed_nillable_submodel():
+    class TestSumModel(BaseXmlModel):
+        text: str
+
+    class TestModel(BaseXmlModel, tag='model'):
+        @computed_element(tag='submodel1', nillable=True)
+        def submodel1(self) -> Optional[TestSumModel]:
+            return None
+
+    xml = '''
+    <model>
+        <submodel1 xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
     </model>
     '''
 

--- a/tests/test_heterogeneous_collections.py
+++ b/tests/test_heterogeneous_collections.py
@@ -27,6 +27,27 @@ def test_set_of_primitives_extraction():
     assert_xml_equal(actual_xml, xml)
 
 
+def test_tuple_of_nillable_primitives_extraction():
+    class TestModel(BaseXmlModel, tag='model1'):
+        elements: Tuple[Optional[int], Optional[float], Optional[str]] = element(tag='element', nillable=True)
+
+    xml = '''
+    <model1>
+        <element>1</element>
+        <element xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+        <element>string3</element>
+    </model1>
+    '''
+
+    actual_obj = TestModel.from_xml(xml)
+    expected_obj = TestModel(elements=(1, None, "string3"))
+
+    assert actual_obj == expected_obj
+
+    actual_xml = actual_obj.to_xml()
+    assert_xml_equal(actual_xml, xml)
+
+
 def test_tuple_of_submodel_extraction():
     class TestSubModel1(BaseXmlModel):
         attr1: int = attr()

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -1,5 +1,5 @@
 import datetime as dt
-from typing import Generic, TypeVar
+from typing import Generic, Optional, TypeVar
 
 from helpers import assert_xml_equal
 
@@ -52,6 +52,37 @@ def test_attrs_and_elements_extraction():
 
     actual_xml = actual_obj.to_xml()
     assert_xml_equal(actual_xml, xml)
+
+
+def test_nillable_element_extraction():
+    class TestModel(BaseXmlModel, tag='model'):
+        element1: Optional[int] = element(default=None, nillable=True)
+        element2: Optional[int] = element(default=None, nillable=True)
+        element3: Optional[int] = element(default=None, nillable=True)
+
+    src_xml = '''
+    <model>
+        <element1 xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+        <element2 xsi:nil="false" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">2</element2>
+        <element3>3</element3>
+    </model>
+    '''
+
+    actual_obj = TestModel.from_xml(src_xml)
+    expected_obj = TestModel(element1=None, element2=2, element3=3)
+
+    assert actual_obj == expected_obj
+
+    actual_xml = actual_obj.to_xml()
+    expected_xml = '''
+    <model>
+        <element1 xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+        <element2>2</element2>
+        <element3>3</element3>
+    </model>
+    '''
+
+    assert_xml_equal(actual_xml, expected_xml)
 
 
 def test_model_inheritance():
@@ -188,6 +219,25 @@ def test_root_model_element_extraction():
 
     actual_obj = TestModel.from_xml(xml)
     expected_obj = TestModel(1)
+
+    assert actual_obj == expected_obj
+
+    actual_xml = actual_obj.to_xml()
+    assert_xml_equal(actual_xml, xml)
+
+
+def test_root_model_nillable_element_extraction():
+    class TestModel(RootXmlModel, tag='model'):
+        root: Optional[int] = element(tag="element1", default=None, nillable=True)
+
+    xml = '''
+    <model>
+        <element1 xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+    </model>
+    '''
+
+    actual_obj = TestModel.from_xml(xml)
+    expected_obj = TestModel()
 
     assert actual_obj == expected_obj
 

--- a/tests/test_submodels.py
+++ b/tests/test_submodels.py
@@ -54,6 +54,44 @@ def test_optional_submodel_element_extraction():
     assert_xml_equal(actual_xml, xml)
 
 
+def test_nillable_submodel_element_extraction():
+    class TestSubModel(BaseXmlModel):
+        text: int
+
+    class TestModel(BaseXmlModel, tag='model1'):
+        model2: Optional[TestSubModel] = element(default=None, nillable=True)
+        model3: Optional[TestSubModel] = element(default=None, nillable=True)
+        model4: Optional[TestSubModel] = element(default=None, nillable=True)
+
+    xml = '''
+    <model1>
+        <model2 xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+        <model3 xsi:nil="false" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">3</model3>
+        <model4>4</model4>
+    </model1>
+    '''
+
+    actual_obj = TestModel.from_xml(xml)
+    expected_obj = TestModel(
+        model2=None,
+        model3=TestSubModel(text=3),
+        model4=TestSubModel(text=4),
+    )
+
+    assert actual_obj == expected_obj
+
+    actual_xml = actual_obj.to_xml()
+    expected_xml = '''
+    <model1>
+        <model2 xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+        <model3>3</model3>
+        <model4>4</model4>
+    </model1>
+    '''
+
+    assert_xml_equal(actual_xml, expected_xml)
+
+
 def test_root_submodel_element_extraction():
     class TestSubModel(RootXmlModel, tag='model2'):
         root: int


### PR DESCRIPTION
Adds nillable elements support. See https://www.w3.org/TR/xmlschema-1/#xsi_nil.

Code example:

```python
>>> from typing import Optional
>>> from pydantic_xml import BaseXmlModel, element
>>> 
>>> class Company(BaseXmlModel):
...     title: Optional[str] = element(default=None, nillable=True)
... 
>>> company = Company()
>>> print(company.to_xml(pretty_print=True).decode())
<Company>
  <title xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"></title>
</Company>

>>> company = Company(title='SpaceX')
>>> print(company.to_xml(pretty_print=True).decode())
<Company>
  <title>SpaceX</title>
</Company>
```


Fixes https://github.com/dapper91/pydantic-xml/issues/145 issue.