### PR TITLE
optional raw element bug fixed.

### DIFF
--- a/pydantic_xml/serializers/factories/raw.py
+++ b/pydantic_xml/serializers/factories/raw.py
@@ -32,7 +32,7 @@ class ElementSerializer(Serializer):
     def serialize(
             self, element: XmlElementWriter, value: Any, encoded: Any, *, skip_empty: bool = False,
     ) -> Optional[XmlElementWriter]:
-        if value is None and skip_empty:
+        if value is None:
             return element
 
         sub_element = element.from_native(value)

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from helpers import assert_xml_equal
 
@@ -38,6 +38,29 @@ def test_raw_primitive_element_serialization():
     element2.append(sub_element)
 
     actual_obj = TestModel(element1=element1, element2=element2)
+    actual_xml = actual_obj.to_xml()
+    assert_xml_equal(actual_xml, xml)
+
+
+def test_optional_raw_primitive_element_serialization():
+    class TestModel(BaseXmlModel, tag='model', arbitrary_types_allowed=True):
+        element1: Optional[ElementT] = element(default=None)
+        element2: ElementT = element()
+
+    xml = '''
+    <model>
+        <element2>text</element2>
+    </model>
+    '''
+
+    actual_obj = TestModel.from_xml(xml)
+
+    assert actual_obj.element1 is None
+    assert actual_obj.element2.text == 'text'
+
+    element2 = etree.Element('element2')
+    element2.text = 'text'
+    actual_obj = TestModel(element1=None, element2=element2)
     actual_xml = actual_obj.to_xml()
     assert_xml_equal(actual_xml, xml)
 


### PR DESCRIPTION
Fixes the bug with optional raw element.

_Example_:

```python
>>> class Model(BaseXmlModel, tag='model', arbitrary_types_allowed=True):
...     element1: Optional[ElementT] = element(default=None)
...
>>> Model().to_xml()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.11/site-packages/pydantic_xml/model.py", line 399, in to_xml
    return etree.tostring(self.to_xml_tree(skip_empty=skip_empty), **kwargs)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pydantic_xml/model.py", line 380, in to_xml_tree
    self.__xml_serializer__.serialize(
  File "/usr/local/lib/python3.11/site-packages/pydantic_xml/serializers/factories/model.py", line 170, in serialize
    field_serializer.serialize(
  File "/usr/local/lib/python3.11/site-packages/pydantic_xml/serializers/factories/raw.py", line 38, in serialize
    sub_element = element.from_native(value)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pydantic_xml/element/native/lxml.py", line 22, in from_native
    tag=element.tag,
        ^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'tag'
```

_Expected behavior_:

```python
>>> from pydantic_xml import BaseXmlModel, element
>>> from xml.etree.ElementTree import Element
>>> from typing import Optional
>>> 
>>> class Model(BaseXmlModel, tag='model', arbitrary_types_allowed=True):
...     element1: Optional[Element] = element(default=None)
... 
>>> print(Model().to_xml().decode())
<model/>
```


fixes the issue https://github.com/dapper91/pydantic-xml/issues/158