### PR TITLE
Union collection deserialization bugfix

### DIFF
--- a/pydantic_xml/element/element.py
+++ b/pydantic_xml/element/element.py
@@ -305,6 +305,7 @@ class XmlElement(XmlElementReader, XmlElementWriter, Generic[NativeElement]):
             attributes=dict(self._state.attrib) if self._state.attrib is not None else None,
             elements=[element.create_snapshot() for element in self._state.elements],
             nsmap=dict(self._nsmap) if self._nsmap is not None else None,
+            sourceline=self._sourceline,
         )
         element._state.next_element_idx = self._state.next_element_idx
 

--- a/pydantic_xml/element/element.py
+++ b/pydantic_xml/element/element.py
@@ -117,6 +117,12 @@ class XmlElementReader(abc.ABC):
         """
 
     @abc.abstractmethod
+    def step_forward(self) -> None:
+        """
+        Increment the current element index.
+        """
+
+    @abc.abstractmethod
     def to_native(self) -> Any:
         """
         Transforms current element to a native one.
@@ -319,6 +325,9 @@ class XmlElement(XmlElementReader, XmlElementWriter, Generic[NativeElement]):
         self._state.attrib = snapshot._state.attrib
         self._state.elements = snapshot._state.elements
         self._state.next_element_idx = snapshot._state.next_element_idx
+
+    def step_forward(self) -> None:
+        self._state.next_element_idx += 1
 
     def is_empty(self) -> bool:
         if not self._state.text and not self._state.tail and not self._state.attrib and len(self._state.elements) == 0:

--- a/pydantic_xml/serializers/factories/union.py
+++ b/pydantic_xml/serializers/factories/union.py
@@ -117,6 +117,7 @@ class ModelSerializer(Serializer):
                 last_error = e
 
         if last_error is not None:
+            element.step_forward()
             raise last_error
 
         return result


### PR DESCRIPTION
Union collection deserialization bug fixed.

Deserialization process gets stuck for List[Union] typed field because element index is not incremented if a validation error is raised.

Code example:

```python
from typing import List, Union
from pydantic_xml import BaseXmlModel

class TestSubModel1(BaseXmlModel, tag='submodel1'):
    data: int

class TestSubModel2(BaseXmlModel, tag='submodel2'):
    data: float

class TestModel(BaseXmlModel, tag='model'):
    submodel: List[Union[TestSubModel1, TestSubModel2]]

xml = '''
    <model>
        <submodel2>a</submodel2>
        <submodel1>b</submodel1>
    </model>
'''

TestModel.from_xml(xml)

```

Fixes the [issue](https://github.com/dapper91/pydantic-xml/issues/164).