### PR TITLE
Pydantic 2.6 compatibility fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,5 +72,5 @@ repos:
         pass_filenames: false
         args: ["--package", "pydantic_xml"]
         additional_dependencies:
-          - pydantic>=2.0.0
+          - pydantic>=2.6.0
           - lxml-stubs>=0.4.0

--- a/pydantic_xml/model.py
+++ b/pydantic_xml/model.py
@@ -6,6 +6,7 @@ import pydantic as pd
 import pydantic_core as pdc
 from pydantic import BaseModel, RootModel
 from pydantic._internal._model_construction import ModelMetaclass  # noqa
+from pydantic.root_model import _RootModelMetaclass as RootModelMetaclass  # noqa
 
 from . import config, errors, utils
 from .element import SearchMode
@@ -433,6 +434,10 @@ class BaseXmlModel(BaseModel, __xml_abstract__=True, metaclass=XmlModelMeta):
         return etree.tostring(self.to_xml_tree(skip_empty=skip_empty), **kwargs)
 
 
+class RootXmlModelMeta(XmlModelMeta, RootModelMetaclass):
+    pass
+
+
 RootModelRootType = TypeVar('RootModelRootType')
 
 
@@ -440,6 +445,7 @@ class RootXmlModel(
     RootModel[RootModelRootType],
     BaseXmlModel,
     Generic[RootModelRootType],
+    metaclass=RootXmlModelMeta,
     __xml_abstract__=True,
 ):
     """

--- a/pydantic_xml/serializers/factories/__init__.py
+++ b/pydantic_xml/serializers/factories/__init__.py
@@ -1,2 +1,2 @@
-from . import heterogeneous, homogeneous, is_instance, mapping, model, primitive, raw, tagged_union, typed_mapping
-from . import union, wrapper
+from . import heterogeneous, homogeneous, is_instance, mapping, model, primitive, raw, tagged_union, tuple
+from . import typed_mapping, union, wrapper

--- a/pydantic_xml/serializers/factories/heterogeneous.py
+++ b/pydantic_xml/serializers/factories/heterogeneous.py
@@ -11,7 +11,7 @@ from pydantic_xml.typedefs import EntityLocation, Location
 
 class ElementSerializer(Serializer):
     @classmethod
-    def from_core_schema(cls, schema: pcs.TuplePositionalSchema, ctx: Serializer.Context) -> 'ElementSerializer':
+    def from_core_schema(cls, schema: pcs.TupleSchema, ctx: Serializer.Context) -> 'ElementSerializer':
         model_name = ctx.model_name
         computed = ctx.field_computed
         inner_serializers: List[Serializer] = []
@@ -73,7 +73,7 @@ class ElementSerializer(Serializer):
             return result
 
 
-def from_core_schema(schema: pcs.TuplePositionalSchema, ctx: Serializer.Context) -> Serializer:
+def from_core_schema(schema: pcs.TupleSchema, ctx: Serializer.Context) -> Serializer:
     for item_schema in schema['items_schema']:
         item_schema, ctx = Serializer.preprocess_schema(item_schema, ctx)
 

--- a/pydantic_xml/serializers/factories/tuple.py
+++ b/pydantic_xml/serializers/factories/tuple.py
@@ -1,0 +1,21 @@
+from pydantic_core import core_schema as pcs
+
+from pydantic_xml import errors
+from pydantic_xml.serializers.serializer import Serializer
+
+from . import heterogeneous, homogeneous
+
+
+def from_core_schema(schema: pcs.TupleSchema, ctx: Serializer.Context) -> Serializer:
+    # Starting from pydantic-core 2.15.0 `tuple-positional` and `tuple-variable` types
+    # had been merged into a single `tuple` type to be able to handle variadic tuples (PEP-646).
+    # Since that point is not possible to separate tuple into homogeneous and heterogeneous collections
+    # by its type but only by presence of the `variadic_item_index` field in the schema.
+    if (variadic_item_index := schema.get('variadic_item_index')) is not None:
+        if variadic_item_index != 0:
+            raise errors.ModelFieldError(
+                ctx.model_name, ctx.field_name, "variadic tuples with prefixed items are not supported",
+            )
+        return homogeneous.from_core_schema(schema, ctx)
+    else:
+        return heterogeneous.from_core_schema(schema, ctx)

--- a/pydantic_xml/serializers/serializer.py
+++ b/pydantic_xml/serializers/serializer.py
@@ -30,7 +30,7 @@ class SchemaTypeFamily(IntEnum):
     PRIMITIVE = 1
     MODEL = 2
     HOMOGENEOUS_COLLECTION = 3
-    HETEROGENEOUS_COLLECTION = 4
+    TUPLE = 4
     MAPPING = 5
     TYPED_MAPPING = 6
     UNION = 7
@@ -64,12 +64,10 @@ TYPE_FAMILY = {
 
     'model':            SchemaTypeFamily.MODEL,
 
-    'tuple-variable':   SchemaTypeFamily.HOMOGENEOUS_COLLECTION,
+    'tuple':            SchemaTypeFamily.TUPLE,
     'list':             SchemaTypeFamily.HOMOGENEOUS_COLLECTION,
     'set':              SchemaTypeFamily.HOMOGENEOUS_COLLECTION,
     'frozenset':        SchemaTypeFamily.HOMOGENEOUS_COLLECTION,
-
-    'tuple-positional': SchemaTypeFamily.HETEROGENEOUS_COLLECTION,
 
     'dict':             SchemaTypeFamily.MAPPING,
     'typed-dict':       SchemaTypeFamily.TYPED_MAPPING,
@@ -242,9 +240,9 @@ class Serializer(abc.ABC):
             schema = typing.cast(factories.homogeneous.HomogeneousCollectionTypeSchema, schema)
             return factories.homogeneous.from_core_schema(schema, ctx)
 
-        elif type_family is SchemaTypeFamily.HETEROGENEOUS_COLLECTION:
-            schema = typing.cast(pcs.TuplePositionalSchema, schema)
-            return factories.heterogeneous.from_core_schema(schema, ctx)
+        elif type_family is SchemaTypeFamily.TUPLE:
+            schema = typing.cast(pcs.TupleSchema, schema)
+            return factories.tuple.from_core_schema(schema, ctx)
 
         elif type_family is SchemaTypeFamily.MAPPING:
             schema = typing.cast(pcs.DictSchema, schema)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
 python = ">=3.8"
 lxml = {version = ">=4.9.0", optional = true}
 pydantic = ">=2.6.0"
+pydantic-core = ">=2.15.0"
 
 furo = {version = "^2022.12.7", optional = true}
 Sphinx = {version = "^5.3.0", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.8"
 lxml = {version = ">=4.9.0", optional = true}
-pydantic = ">=2.0.0"
+pydantic = ">=2.6.0"
 
 furo = {version = "^2022.12.7", optional = true}
 Sphinx = {version = "^5.3.0", optional = true}


### PR DESCRIPTION
Starting from pydantic-core 2.15.0 `tuple-positional` and `tuple-variable` types had been [merged](https://github.com/pydantic/pydantic-core/commit/4df7624c12b57dc47fe1de72acb2795c1631dbb9) into a single `tuple` type to be able to handle variadic tuples ([PEP-646](https://peps.python.org/pep-0646/)). Since that point is not possible to separate tuple into homogeneous and heterogeneous collections by its type but only by presence of the `variadic_item_index` field in the schema.

Fixes the issue https://github.com/dapper91/pydantic-xml/issues/167.