### PR TITLE
PEP-681 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_stages:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-yaml
       - id: check-toml
@@ -25,13 +25,13 @@ repos:
         args:
           - --fix=no
   - repo: https://github.com/asottile/add-trailing-comma
-    rev: v3.0.0
+    rev: v3.1.0
     hooks:
       - id: add-trailing-comma
         stages:
           - commit
   - repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v2.0.2
+    rev: v2.0.4
     hooks:
       - id: autopep8
         stages:
@@ -39,11 +39,11 @@ repos:
         args:
           - --diff
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.0.0
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: fix import order
@@ -63,7 +63,7 @@ repos:
           - --multi-line=9
           - --project=pydantic_xml
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.1
+    rev: v1.9.0
     hooks:
       - id: mypy
         stages:

--- a/pydantic_xml/model.py
+++ b/pydantic_xml/model.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, ClassVar, Dict, Generic, Optional, Tuple, Type
 
 import pydantic as pd
 import pydantic_core as pdc
+import typing_extensions as te
 from pydantic import BaseModel, RootModel
 from pydantic._internal._model_construction import ModelMetaclass  # noqa
 from pydantic.root_model import _RootModelMetaclass as RootModelMetaclass  # noqa
@@ -249,6 +250,7 @@ def wrapped(
     )
 
 
+@te.dataclass_transform(kw_only_default=True, field_specifiers=(attr, element, wrapped, pd.Field))
 class XmlModelMeta(ModelMetaclass):
     """
     Xml model metaclass.
@@ -434,6 +436,7 @@ class BaseXmlModel(BaseModel, __xml_abstract__=True, metaclass=XmlModelMeta):
         return etree.tostring(self.to_xml_tree(skip_empty=skip_empty), **kwargs)
 
 
+@te.dataclass_transform(kw_only_default=True, field_specifiers=(attr, element, wrapped, pd.Field))
 class RootXmlModelMeta(XmlModelMeta, RootModelMetaclass):
     pass
 


### PR DESCRIPTION
[PEP 681](https://peps.python.org/pep-0681/) proposes a way to indicate that a class support dataclass-like semantics. It helps static type checkers like mypy, pylance (pyright) to check a class instantiation.

Fixes the [issue](https://github.com/dapper91/pydantic-xml/issues/152).