### PR TITLE
pydantic 2.7 compatibility fixes.

### DIFF
--- a/pydantic_xml/serializers/serializer.py
+++ b/pydantic_xml/serializers/serializer.py
@@ -48,6 +48,7 @@ TYPE_FAMILY = {
     'float':            SchemaTypeFamily.PRIMITIVE,
     'str':              SchemaTypeFamily.PRIMITIVE,
     'bytes':            SchemaTypeFamily.PRIMITIVE,
+    'enum':             SchemaTypeFamily.PRIMITIVE,
     'date':             SchemaTypeFamily.PRIMITIVE,
     'time':             SchemaTypeFamily.PRIMITIVE,
     'datetime':         SchemaTypeFamily.PRIMITIVE,


### PR DESCRIPTION
- pydantic 2.7 enum type support added.

fixes the [issue](https://github.com/dapper91/pydantic-xml/issues/182) 