### PR TITLE
Remove snapshot from union ModelSerializer

### DIFF
--- a/pydantic_xml/serializers/factories/union.py
+++ b/pydantic_xml/serializers/factories/union.py
@@ -106,12 +106,10 @@ class ModelSerializer(Serializer):
         last_error: Optional[Exception] = None
         result: Any = None
         for serializer in self._inner_serializers:
-            snapshot = element.create_snapshot()
             try:
-                if (result := serializer.deserialize(snapshot, context=context, sourcemap=sourcemap, loc=loc)) is None:
+                if (result := serializer.deserialize(element, context=context, sourcemap=sourcemap, loc=loc)) is None:
                     continue
                 else:
-                    element.apply_snapshot(snapshot)
                     return result
             except pd.ValidationError as e:
                 last_error = e


### PR DESCRIPTION
This PR removes what I *think* is an unnecessary safety feature.

I'm trying to parse a structure with a long list of varying types:

```
class PublicWhip(BaseXmlModel, tag="publicwhip"):
    scraper_version: str = attr("scraperversion")
    latest: str = attr()
    items: list[OralHeading | MajorHeading | MinorHeading | Speech | Division ]
```

This worked - but took about 50 seconds. Looking into it, the big slowdown is the recursive snapshotting - running over thousands of elements five times. 

Taking out this snapshot made the load under a second, and as far as I can tell snapshot isn't preventing any harmful effects. 

 The only thing effecting element is `pop_element` - which either returns something (and the snapshot updates the element through `apply_snapshot` anyway) - or didn't find anything, returns None, and the element is unaltered anyway. 

I can monkeypatch for my purposes but thought I'd do a PR to check I'm right it makes no difference. 