### PR TITLE
exclude_none and exclude_unset flags support added.

### DIFF
--- a/docs/source/pages/misc.rst
+++ b/docs/source/pages/misc.rst
@@ -97,6 +97,33 @@ for a particular model during its declaration as illustrated in the following ex
     :start-after: xml-start
     :end-before: xml-end
 
+It is also possible to exclude ``None`` values:
+
+.. literalinclude:: ../../../examples/snippets/exclude_none.py
+    :language: python
+    :start-after: model-start
+    :end-before: model-end
+
+.. literalinclude:: ../../../examples/snippets/exclude_none.py
+    :language: xml
+    :lines: 2-
+    :start-after: xml-start
+    :end-before: xml-end
+
+
+... or unset values:
+
+.. literalinclude:: ../../../examples/snippets/exclude_unset.py
+    :language: python
+    :start-after: model-start
+    :end-before: model-end
+
+.. literalinclude:: ../../../examples/snippets/exclude_unset.py
+    :language: xml
+    :lines: 2-
+    :start-after: xml-start
+    :end-before: xml-end
+
 
 Default namespace
 ~~~~~~~~~~~~~~~~~

--- a/examples/snippets/exclude_none.py
+++ b/examples/snippets/exclude_none.py
@@ -1,0 +1,26 @@
+from typing import Literal, Optional
+from xml.etree.ElementTree import canonicalize
+
+from pydantic_xml import BaseXmlModel, element
+
+
+# [model-start]
+class Product(BaseXmlModel, tag='Product'):
+    title: Optional[str] = element(tag='Title', default=None)
+    status: Optional[Literal['running', 'development']] = element(tag='Status', default=None)
+    launched: Optional[int] = element(tag='Launched', default=None)
+
+
+product = Product(title="Starlink", status=None)
+xml = product.to_xml(exclude_none=True)
+# [model-end]
+
+
+# [xml-start]
+xml_doc = '''
+<Product>
+    <Title>Starlink</Title>
+</Product>
+'''  # [xml-end]
+
+assert canonicalize(xml, strip_text=True) == canonicalize(xml_doc, strip_text=True)

--- a/examples/snippets/exclude_unset.py
+++ b/examples/snippets/exclude_unset.py
@@ -1,0 +1,27 @@
+from typing import Literal, Optional
+from xml.etree.ElementTree import canonicalize
+
+from pydantic_xml import BaseXmlModel, element
+
+
+# [model-start]
+class Product(BaseXmlModel, tag='Product'):
+    title: Optional[str] = element(tag='Title', default=None)
+    status: Optional[Literal['running', 'development']] = element(tag='Status', default=None)
+    launched: Optional[int] = element(tag='Launched', default=None)
+
+
+product = Product(title="Starlink", status=None)
+xml = product.to_xml(exclude_unset=True)
+# [model-end]
+
+
+# [xml-start]
+xml_doc = '''
+<Product>
+    <Title>Starlink</Title>
+    <Status />
+</Product>
+'''  # [xml-end]
+
+assert canonicalize(xml, strip_text=True) == canonicalize(xml_doc, strip_text=True)

--- a/pydantic_xml/model.py
+++ b/pydantic_xml/model.py
@@ -469,11 +469,15 @@ class BaseXmlModel(BaseModel, __xml_abstract__=True, metaclass=XmlModelMeta):
 
         return cls.from_xml_tree(etree.fromstring(source), context=context)
 
-    def to_xml_tree(self, *, skip_empty: bool = False) -> etree.Element:
+    def to_xml_tree(
+            self, *, skip_empty: bool = False, exclude_none: bool = False, exclude_unset: bool = False,
+    ) -> etree.Element:
         """
         Serializes the object to an xml tree.
 
         :param skip_empty: skip empty elements (elements without sub-elements, attributes and text, Nones)
+        :param exclude_none: exclude `None` values
+        :param exclude_unset: exclude values that haven't been explicitly set
         :return: object xml representation
         """
 
@@ -485,21 +489,31 @@ class BaseXmlModel(BaseModel, __xml_abstract__=True, metaclass=XmlModelMeta):
                 self,
                 by_alias=False,
                 fallback=lambda obj: obj if not isinstance(obj, ElementT) else None,  # for raw fields support
-            ), skip_empty=skip_empty,
+            ),
+            skip_empty=skip_empty,
+            exclude_none=exclude_none,
+            exclude_unset=exclude_unset,
         )
 
         return root.to_native()
 
-    def to_xml(self, *, skip_empty: bool = False, **kwargs: Any) -> Union[str, bytes]:
+    def to_xml(
+            self, *, skip_empty: bool = False, exclude_none: bool = False, exclude_unset: bool = False, **kwargs: Any,
+    ) -> Union[str, bytes]:
         """
         Serializes the object to an xml string.
 
         :param skip_empty: skip empty elements (elements without sub-elements, attributes and text, Nones)
+        :param exclude_none: exclude `None` values
+        :param exclude_unset: exclude values that haven't been explicitly set
         :param kwargs: additional xml serialization arguments
         :return: object xml representation
         """
 
-        return etree.tostring(self.to_xml_tree(skip_empty=skip_empty), **kwargs)
+        return etree.tostring(
+            self.to_xml_tree(skip_empty=skip_empty, exclude_none=exclude_none, exclude_unset=exclude_unset),
+            **kwargs,
+        )
 
 
 @te.dataclass_transform(kw_only_default=True, field_specifiers=(attr, element, wrapped, pd.Field))

--- a/pydantic_xml/serializers/factories/heterogeneous.py
+++ b/pydantic_xml/serializers/factories/heterogeneous.py
@@ -26,7 +26,14 @@ class ElementSerializer(Serializer):
         self._inner_serializers = inner_serializers
 
     def serialize(
-            self, element: XmlElementWriter, value: List[Any], encoded: List[Any], *, skip_empty: bool = False,
+            self,
+            element: XmlElementWriter,
+            value: List[Any],
+            encoded: List[Any],
+            *,
+            skip_empty: bool = False,
+            exclude_none: bool = False,
+            exclude_unset: bool = False,
     ) -> Optional[XmlElementWriter]:
         if value is None:
             return element
@@ -38,7 +45,9 @@ class ElementSerializer(Serializer):
             raise errors.SerializationError("value length is incorrect")
 
         for serializer, val, enc in zip(self._inner_serializers, value, encoded):
-            serializer.serialize(element, val, enc, skip_empty=skip_empty)
+            serializer.serialize(
+                element, val, enc, skip_empty=skip_empty, exclude_none=exclude_none, exclude_unset=exclude_unset,
+            )
 
         return element
 

--- a/pydantic_xml/serializers/factories/homogeneous.py
+++ b/pydantic_xml/serializers/factories/homogeneous.py
@@ -38,7 +38,14 @@ class ElementSerializer(Serializer):
         self._inner_serializer = inner_serializer
 
     def serialize(
-            self, element: XmlElementWriter, value: List[Any], encoded: List[Any], *, skip_empty: bool = False,
+            self,
+            element: XmlElementWriter,
+            value: List[Any],
+            encoded: List[Any],
+            *,
+            skip_empty: bool = False,
+            exclude_none: bool = False,
+            exclude_unset: bool = False,
     ) -> Optional[XmlElementWriter]:
         if value is None:
             return element
@@ -50,7 +57,9 @@ class ElementSerializer(Serializer):
             if skip_empty and val is None:
                 continue
 
-            self._inner_serializer.serialize(element, val, enc, skip_empty=skip_empty)
+            self._inner_serializer.serialize(
+                element, val, enc, skip_empty=skip_empty, exclude_none=exclude_none, exclude_unset=exclude_unset,
+            )
 
         return element
 

--- a/pydantic_xml/serializers/factories/mapping.py
+++ b/pydantic_xml/serializers/factories/mapping.py
@@ -32,6 +32,8 @@ class AttributesSerializer(Serializer):
             encoded: Dict[str, Any],
             *,
             skip_empty: bool = False,
+            exclude_none: bool = False,
+            exclude_unset: bool = False,
     ) -> Optional[XmlElementWriter]:
         if value is None:
             return element
@@ -100,12 +102,16 @@ class ElementSerializer(AttributesSerializer):
             encoded: Dict[str, Any],
             *,
             skip_empty: bool = False,
+            exclude_none: bool = False,
+            exclude_unset: bool = False,
     ) -> Optional[XmlElementWriter]:
         if skip_empty and len(value) == 0:
             return element
 
         sub_element = element.make_element(self._element_name, nsmap=self._nsmap)
-        super().serialize(sub_element, value, encoded, skip_empty=skip_empty)
+        super().serialize(
+            sub_element, value, encoded, skip_empty=skip_empty, exclude_none=exclude_none, exclude_unset=exclude_unset,
+        )
         if skip_empty and sub_element.is_empty():
             return None
         else:

--- a/pydantic_xml/serializers/factories/named_tuple.py
+++ b/pydantic_xml/serializers/factories/named_tuple.py
@@ -26,9 +26,18 @@ class ElementSerializer(Serializer):
         self._inner_serializer = heterogeneous.ElementSerializer(model_name, computed, inner_serializers)
 
     def serialize(
-            self, element: XmlElementWriter, value: List[Any], encoded: List[Any], *, skip_empty: bool = False,
+            self,
+            element: XmlElementWriter,
+            value: List[Any],
+            encoded: List[Any],
+            *,
+            skip_empty: bool = False,
+            exclude_none: bool = False,
+            exclude_unset: bool = False,
     ) -> Optional[XmlElementWriter]:
-        return self._inner_serializer.serialize(element, value, encoded, skip_empty=skip_empty)
+        return self._inner_serializer.serialize(
+            element, value, encoded, skip_empty=skip_empty, exclude_none=exclude_none, exclude_unset=exclude_unset,
+        )
 
     def deserialize(
             self,

--- a/pydantic_xml/serializers/factories/primitive.py
+++ b/pydantic_xml/serializers/factories/primitive.py
@@ -41,9 +41,16 @@ class TextSerializer(Serializer):
         self._nillable = nillable
 
     def serialize(
-            self, element: XmlElementWriter, value: Any, encoded: Any, *, skip_empty: bool = False,
+            self,
+            element: XmlElementWriter,
+            value: Any,
+            encoded: Any,
+            *,
+            skip_empty: bool = False,
+            exclude_none: bool = False,
+            exclude_unset: bool = False,
     ) -> Optional[XmlElementWriter]:
-        if value is None and skip_empty:
+        if value is None and (skip_empty or exclude_none):
             return element
 
         if self._nillable and value is None:
@@ -101,9 +108,16 @@ class AttributeSerializer(Serializer):
         return self._attr_name
 
     def serialize(
-            self, element: XmlElementWriter, value: Any, encoded: Any, *, skip_empty: bool = False,
+            self,
+            element: XmlElementWriter,
+            value: Any,
+            encoded: Any,
+            *,
+            skip_empty: bool = False,
+            exclude_none: bool = False,
+            exclude_unset: bool = False,
     ) -> Optional[XmlElementWriter]:
-        if value is None and skip_empty:
+        if value is None and (skip_empty or exclude_none):
             return element
 
         element.set_attribute(self._attr_name, encode_primitive(encoded))
@@ -158,13 +172,22 @@ class ElementSerializer(TextSerializer):
         self._element_name = QName.from_alias(tag=name, ns=ns, nsmap=nsmap).uri
 
     def serialize(
-            self, element: XmlElementWriter, value: Any, encoded: Any, *, skip_empty: bool = False,
+            self,
+            element: XmlElementWriter,
+            value: Any,
+            encoded: Any,
+            *,
+            skip_empty: bool = False,
+            exclude_none: bool = False,
+            exclude_unset: bool = False,
     ) -> Optional[XmlElementWriter]:
-        if value is None and skip_empty:
+        if value is None and (skip_empty or exclude_none):
             return element
 
         sub_element = element.make_element(self._element_name, nsmap=self._nsmap)
-        super().serialize(sub_element, value, encoded, skip_empty=skip_empty)
+        super().serialize(
+            sub_element, value, encoded, skip_empty=skip_empty, exclude_none=exclude_none, exclude_unset=exclude_unset,
+        )
         if skip_empty and sub_element.is_empty():
             return None
         else:

--- a/pydantic_xml/serializers/factories/raw.py
+++ b/pydantic_xml/serializers/factories/raw.py
@@ -30,7 +30,14 @@ class ElementSerializer(Serializer):
         self._element_name = QName.from_alias(tag=name, ns=ns, nsmap=nsmap).uri
 
     def serialize(
-            self, element: XmlElementWriter, value: Any, encoded: Any, *, skip_empty: bool = False,
+            self,
+            element: XmlElementWriter,
+            value: Any,
+            encoded: Any,
+            *,
+            skip_empty: bool = False,
+            exclude_none: bool = False,
+            exclude_unset: bool = False,
     ) -> Optional[XmlElementWriter]:
         if value is None:
             return element

--- a/pydantic_xml/serializers/factories/tagged_union.py
+++ b/pydantic_xml/serializers/factories/tagged_union.py
@@ -73,9 +73,13 @@ class ModelSerializer(Serializer):
             encoded: Dict[str, Any],
             *,
             skip_empty: bool = False,
+            exclude_none: bool = False,
+            exclude_unset: bool = False,
     ) -> Optional[XmlElementWriter]:
         if (tag := encoded.get(self._discriminator)) and (serializer := self._inner_serializers[tag]):
-            return serializer.serialize(element, value, encoded, skip_empty=skip_empty)
+            return serializer.serialize(
+                element, value, encoded, skip_empty=skip_empty, exclude_none=exclude_none, exclude_unset=exclude_unset,
+            )
 
         return None
 

--- a/pydantic_xml/serializers/factories/union.py
+++ b/pydantic_xml/serializers/factories/union.py
@@ -35,9 +35,18 @@ class PrimitiveTypeSerializer(Serializer):
         self._inner_serializer = inner_serializer
 
     def serialize(
-            self, element: XmlElementWriter, value: Any, encoded: Any, *, skip_empty: bool = False,
+            self,
+            element: XmlElementWriter,
+            value: Any,
+            encoded: Any,
+            *,
+            skip_empty: bool = False,
+            exclude_none: bool = False,
+            exclude_unset: bool = False,
     ) -> Optional[XmlElementWriter]:
-        return self._inner_serializer.serialize(element, value, encoded, skip_empty=skip_empty)
+        return self._inner_serializer.serialize(
+            element, value, encoded, skip_empty=skip_empty, exclude_none=exclude_none, exclude_unset=exclude_unset,
+        )
 
     def deserialize(
             self,
@@ -82,10 +91,17 @@ class ModelSerializer(Serializer):
             encoded: Dict[str, Any],
             *,
             skip_empty: bool = False,
+            exclude_none: bool = False,
+            exclude_unset: bool = False,
     ) -> Optional[XmlElementWriter]:
         for serializer in self._inner_serializers:
             if serializer.model is type(value):
-                return serializer.serialize(element, value, encoded, skip_empty=skip_empty)
+                return serializer.serialize(
+                    element, value, encoded,
+                    skip_empty=skip_empty,
+                    exclude_none=exclude_none,
+                    exclude_unset=exclude_unset,
+                )
 
         return None
 

--- a/pydantic_xml/serializers/factories/wrapper.py
+++ b/pydantic_xml/serializers/factories/wrapper.py
@@ -40,7 +40,14 @@ class ElementPathSerializer(Serializer):
         self._inner_serializer = inner_serializer
 
     def serialize(
-            self, element: XmlElementWriter, value: Any, encoded: Any, *, skip_empty: bool = False,
+            self,
+            element: XmlElementWriter,
+            value: Any,
+            encoded: Any,
+            *,
+            skip_empty: bool = False,
+            exclude_none: bool = False,
+            exclude_unset: bool = False,
     ) -> Optional[XmlElementWriter]:
         if value is None:
             return element
@@ -51,7 +58,9 @@ class ElementPathSerializer(Serializer):
         for part in self._path:
             element = element.find_element_or_create(part, self._search_mode, nsmap=self._nsmap)
 
-        self._inner_serializer.serialize(element, value, encoded, skip_empty=skip_empty)
+        self._inner_serializer.serialize(
+            element, value, encoded, skip_empty=skip_empty, exclude_none=exclude_none, exclude_unset=exclude_unset,
+        )
 
         return element
 

--- a/pydantic_xml/serializers/serializer.py
+++ b/pydantic_xml/serializers/serializer.py
@@ -277,7 +277,14 @@ class Serializer(abc.ABC):
 
     @abc.abstractmethod
     def serialize(
-            self, element: XmlElementWriter, value: Any, encoded: Any, *, skip_empty: bool = False,
+            self,
+            element: XmlElementWriter,
+            value: Any,
+            encoded: Any,
+            *,
+            skip_empty: bool = False,
+            exclude_none: bool = False,
+            exclude_unset: bool = False,
     ) -> Optional[XmlElementWriter]:
         """
         Serializes a value to the provided xml element.
@@ -286,6 +293,8 @@ class Serializer(abc.ABC):
         :param value: original value
         :param encoded: encoded value (encoded by pydantic)
         :param skip_empty: skip empty element
+        :param exclude_none: exclude `None` values
+        :param exclude_unset: exclude unset values
         :return: created sub-element or original one if sub-element has not been created
         """
 

--- a/tests/test_unions.py
+++ b/tests/test_unions.py
@@ -388,3 +388,28 @@ def test_path_discriminated_model_tagged_union():
 
     actual_xml = actual_obj.to_xml()
     assert_xml_equal(actual_xml, xml)
+
+
+def test_union_snapshot():
+    class SubModel1(BaseXmlModel, tag='submodel'):
+        attr1: int = attr()
+
+    class SubModel2(BaseXmlModel, tag='submodel'):
+        attr1: str = attr()
+
+    class TestModel(BaseXmlModel, tag='model'):
+        element1: Union[SubModel1, SubModel2]
+
+    xml = '''
+    <model>
+        <submodel attr1="a" />
+    </model>
+    '''
+
+    actual_obj = TestModel.from_xml(xml)
+    expected_obj = TestModel(element1=SubModel2(attr1="a"))
+
+    assert actual_obj == expected_obj
+
+    actual_xml = actual_obj.to_xml()
+    assert_xml_equal(actual_xml, xml)


### PR DESCRIPTION
Adds support for ``exclude_none`` and ``exclude_unset`` serialization flags. 

* exclude_none - excludes model fields set to `None`:

```python
>>> from typing import Literal, Optional
>>> from xml.etree.ElementTree import canonicalize
>>> 
>>> from pydantic_xml import BaseXmlModel, element
>>> 
>>> class Product(BaseXmlModel, tag='Product'):
...     title: Optional[str] = element(tag='Title', default=None)
...     status: Optional[Literal['running', 'development']] = element(tag='Status', default=None)
...     launched: Optional[int] = element(tag='Launched', default=None)
... 
>>> product = Product(title="Starlink", status=None)
>>> print(product.to_xml(exclude_none=True, pretty_print=True).decode())
<Product>
  <Title>Starlink</Title>
</Product>
```

* exclude_unset - excludes model fields that haven't been explicitly set:

```python
>>> from typing import Literal, Optional
>>> from xml.etree.ElementTree import canonicalize
>>> 
>>> from pydantic_xml import BaseXmlModel, element
>>> 
>>> class Product(BaseXmlModel, tag='Product'):
...     title: Optional[str] = element(tag='Title', default=None)
...     status: Optional[Literal['running', 'development']] = element(tag='Status', default=None)
...     launched: Optional[int] = element(tag='Launched', default=None)
... 
>>> product = Product(title="Starlink", status=None)
>>> print(product.to_xml(exclude_unset=True, pretty_print=True).decode())
<Product>
  <Title>Starlink</Title>
  <Status></Status>
</Product>

```

Fixes the issues https://github.com/dapper91/pydantic-xml/issues/203 and https://github.com/dapper91/pydantic-xml/issues/194