### PR TITLE
collection of tagged union bug fixed.

### DIFF
--- a/pydantic_xml/serializers/factories/heterogeneous.py
+++ b/pydantic_xml/serializers/factories/heterogeneous.py
@@ -93,6 +93,7 @@ def from_core_schema(schema: pcs.TupleSchema, ctx: Serializer.Context) -> Serial
                 SchemaTypeFamily.MAPPING,
                 SchemaTypeFamily.TYPED_MAPPING,
                 SchemaTypeFamily.UNION,
+                SchemaTypeFamily.TAGGED_UNION,
                 SchemaTypeFamily.IS_INSTANCE,
                 SchemaTypeFamily.CALL,
         ):

--- a/pydantic_xml/serializers/factories/homogeneous.py
+++ b/pydantic_xml/serializers/factories/homogeneous.py
@@ -111,6 +111,7 @@ def from_core_schema(schema: HomogeneousCollectionTypeSchema, ctx: Serializer.Co
         SchemaTypeFamily.MAPPING,
         SchemaTypeFamily.TYPED_MAPPING,
         SchemaTypeFamily.UNION,
+        SchemaTypeFamily.TAGGED_UNION,
         SchemaTypeFamily.IS_INSTANCE,
         SchemaTypeFamily.CALL,
         SchemaTypeFamily.TUPLE,
@@ -122,6 +123,7 @@ def from_core_schema(schema: HomogeneousCollectionTypeSchema, ctx: Serializer.Co
     if items_type_family not in (
             SchemaTypeFamily.MODEL,
             SchemaTypeFamily.UNION,
+            SchemaTypeFamily.TAGGED_UNION,
             SchemaTypeFamily.TUPLE,
             SchemaTypeFamily.CALL,
     ) and ctx.entity_location is None:

--- a/pydantic_xml/serializers/factories/named_tuple.py
+++ b/pydantic_xml/serializers/factories/named_tuple.py
@@ -63,6 +63,7 @@ def from_core_schema(schema: pcs.CallSchema, ctx: Serializer.Context) -> Seriali
                 SchemaTypeFamily.MAPPING,
                 SchemaTypeFamily.TYPED_MAPPING,
                 SchemaTypeFamily.UNION,
+                SchemaTypeFamily.TAGGED_UNION,
                 SchemaTypeFamily.IS_INSTANCE,
                 SchemaTypeFamily.CALL,
         ):


### PR DESCRIPTION
Fixes the bug when a field of a tagged union collection type:

```python
class FloatSubModel(BaseXmlModel):
    type: Literal['float'] = attr()
    data: float


class StringSubModel(BaseXmlModel):
    type: Literal['string'] = attr()
    data: str


TaggedUnion = Annotated[Union[FloatData, StringData], Field(discriminator='type')]

class Model(BaseXmlModel):
    collection: list[TaggedUnion]
```

Fixes the issue https://github.com/dapper91/pydantic-xml/issues/206