### PR TITLE
fix XmlElement::pop_element

### DIFF
--- a/pydantic_xml/element/element.py
+++ b/pydantic_xml/element/element.py
@@ -370,7 +370,14 @@ class XmlElement(XmlElementReader, XmlElementWriter, Generic[NativeElement]):
     def pop_element(self, tag: str, search_mode: 'SearchMode') -> Optional['XmlElement[NativeElement]']:
         searcher: Searcher[NativeElement] = get_searcher(search_mode)
 
-        return searcher(self._state, tag, False, True)
+        # don't step forward, self._state.next_element_idx points to the desired element
+        result = searcher(self._state, tag, False, False)
+        if result is not None:
+            # pop the element, self._state.next_element_idx now points to the first not-found
+            # element
+            self._state.elements.pop(self._state.next_element_idx)
+        return result
+
 
     def find_sub_element(self, path: Sequence[str], search_mode: 'SearchMode') -> PathT['XmlElement[NativeElement]']:
         assert len(path) > 0, "path can't be empty"

--- a/pydantic_xml/element/element.py
+++ b/pydantic_xml/element/element.py
@@ -378,7 +378,6 @@ class XmlElement(XmlElementReader, XmlElementWriter, Generic[NativeElement]):
             self._state.elements.pop(self._state.next_element_idx)
         return result
 
-
     def find_sub_element(self, path: Sequence[str], search_mode: 'SearchMode') -> PathT['XmlElement[NativeElement]']:
         assert len(path) > 0, "path can't be empty"
 

--- a/pydantic_xml/serializers/factories/raw.py
+++ b/pydantic_xml/serializers/factories/raw.py
@@ -63,7 +63,7 @@ class ElementSerializer(Serializer):
         if element is None:
             return None
 
-        if (sub_element := element.pop_element(self._element_name, self._search_mode)) is not None:
+        if (sub_element := element.pop_element(self._element_name, self._search_mode, remove=True)) is not None:
             sourcemap[loc] = sub_element.get_sourceline()
             return sub_element.to_native()
         else:


### PR DESCRIPTION
See the test.

Basically, what was happening before was the following:
If you define a model with `ElementT` fields, the deserializer would deserialize the field as a verbatim copy of the element, but it would not pop it from the parent element. If your model has `extra="forbid"`, the `ModelSerializer` would then check for any extra fields, and it would find all of the `ElementT` fields, as they have not been popped. 

In the old situation, `pop_element` would practically be the same as `find_element`, not modifying the element, but even judging from the name, this is a bug. The test shows the desired behavior, where `extra="forbid"` would not mark any `ElementT` elements as being extra.