### PR TITLE
Fix: namespace inheritance

### DIFF
--- a/pydantic_xml/model.py
+++ b/pydantic_xml/model.py
@@ -421,11 +421,16 @@ class BaseXmlModel(BaseModel, __xml_abstract__=True, metaclass=XmlModelMeta):
 
         cls.__xml_tag__ = tag if tag is not None else getattr(cls, '__xml_tag__', None)
         cls.__xml_ns__ = ns if ns is not None else getattr(cls, '__xml_ns__', None)
-        cls.__xml_nsmap__ = nsmap if nsmap is not None else getattr(cls, '__xml_nsmap__', None)
         cls.__xml_ns_attrs__ = ns_attrs if ns_attrs is not None else getattr(cls, '__xml_ns_attrs__', False)
         cls.__xml_skip_empty__ = skip_empty if skip_empty is not None else getattr(cls, '__xml_skip_empty__', None)
         cls.__xml_search_mode__ = search_mode if search_mode is not None \
             else getattr(cls, '__xml_search_mode__', SearchMode.STRICT)
+
+        if parent_nsmap := getattr(cls, '__xml_nsmap__', None):
+            parent_nsmap.update(nsmap or {})
+            cls.__xml_nsmap__ = parent_nsmap
+        else:
+            cls.__xml_nsmap__ = nsmap
 
         cls.__xml_field_serializers__ = {}
         cls.__xml_field_validators__ = {}

--- a/pydantic_xml/utils.py
+++ b/pydantic_xml/utils.py
@@ -7,6 +7,8 @@ from typing import Dict, Iterable, List, Optional, Union, cast
 import pydantic as pd
 import pydantic_core as pdc
 
+from pydantic_xml import errors
+
 from .element.native import etree
 from .typedefs import Location, NsMap
 
@@ -52,7 +54,13 @@ class QName:
         """
 
         if not is_attr or ns is not None:
-            ns = nsmap.get(ns or '') if nsmap else None
+            if ns is None:
+                ns = nsmap.get('') if nsmap else None
+            else:
+                try:
+                    ns = nsmap[ns] if nsmap else None
+                except KeyError:
+                    raise errors.ModelError(f"namespace alias {ns} not declared in nsmap")
 
         return QName(tag=tag, ns=ns)
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -320,7 +320,7 @@ def test_model_params_inheritance():
         BaseXmlModel,
         tag='TestTag',
         ns='TestNamespace',
-        nsmap={'test': 'value'},
+        nsmap={'TestNamespace': 'value'},
         ns_attrs=True,
         search_mode='ordered',
     ):


### PR DESCRIPTION
- an exception is raised if namespace alias is not found in the namespace map.
- a child model inherits the parent namespace map.