### PR TITLE
allow computed_fields to be retrieved in model_validator's data arg d…

### DIFF
--- a/pydantic_xml/serializers/factories/primitive.py
+++ b/pydantic_xml/serializers/factories/primitive.py
@@ -67,9 +67,6 @@ class TextSerializer(Serializer):
             sourcemap: Dict[Location, int],
             loc: Location,
     ) -> Optional[str]:
-        if self._computed:
-            return None
-
         if element is None:
             return None
 
@@ -132,9 +129,6 @@ class AttributeSerializer(Serializer):
             sourcemap: Dict[Location, int],
             loc: Location,
     ) -> Optional[str]:
-        if self._computed:
-            return None
-
         if element is None:
             return None
 
@@ -202,9 +196,6 @@ class ElementSerializer(TextSerializer):
             sourcemap: Dict[Location, int],
             loc: Location,
     ) -> Optional[str]:
-        if self._computed:
-            return None
-
         if element is None:
             return None
 


### PR DESCRIPTION

# PR

This PR addresses the issue discussed in https://github.com/dapper91/pydantic-xml/issues/259.

## Context
In Pydantic v2, `@computed_field` values are accessible during model validation phases such as `@model_validator(mode="before")` or "`wrap`". While these fields are not meant to be reassigned to the model (as they are derived), there are valid use cases for accessing their raw deserialized values—particularly during early validation.

## Problem
Currently, `pydantic-xml` discards computed fields entirely during deserialization. This prevents developers from accessing raw data that may be essential for reconstructing the full model state, even if the field is not meant to be stored directly.

## Proposal
This PR proposes to retain deserialized values for computed fields, making them available in the data dictionary passed to the `@model_validator hooks`. The computed fields are still not assigned to the model instance, in line with Pydantic's design—but their raw XML content is preserved for downstream inference logic.

## MWE

```python
class Contact(BaseXmlModel):
    first_name: str | None = Field(exclude=True, default=None)
    last_name: str | None = Field(exclude=True, default=None)

    @computed_element(tag="full_name")  # type: ignore
    def full_name(self) -> str:
        return f"{self.first_name}#{self.last_name}"

    @model_validator(mode="wrap")
    @classmethod
    def validator(cls, data: Any, handler: ModelWrapValidatorHandler[Self]) -> Self:
        pass
        model = handler(data)
        if full_name := data.get("full_name", None):
            first_name, last_name = full_name.split("#")
            model.first_name = first_name
            model.last_name = last_name
        return model

obj = Contact(first_name="Lionel", last_name="du Peloux")
xml_string = obj.to_xml(pretty_print=True)
print(xml_string)
print("--------------------------------")
obj = Contact.from_xml(xml_string)
print(obj.to_xml(pretty_print=True, encoding="unicode"))
```