### PR TITLE
fix: multiple field annotations bugfix

### DIFF
--- a/pydantic_xml/__init__.py
+++ b/pydantic_xml/__init__.py
@@ -4,8 +4,9 @@ pydantic xml serialization/deserialization extension
 
 from . import config, errors, model
 from .errors import ModelError, ParsingError
-from .model import BaseXmlModel, RootXmlModel, XmlFieldSerializer, XmlFieldValidator, attr, computed_attr
-from .model import computed_element, create_model, element, wrapped, xml_field_serializer, xml_field_validator
+from .fields import XmlFieldSerializer, XmlFieldValidator, attr, computed_attr, computed_element, element, wrapped
+from .fields import xml_field_serializer, xml_field_validator
+from .model import BaseXmlModel, RootXmlModel, create_model
 
 __all__ = (
     'BaseXmlModel',

--- a/pydantic_xml/fields.py
+++ b/pydantic_xml/fields.py
@@ -36,7 +36,7 @@ class XmlEntityInfoP(typing.Protocol):
     path: Optional[str]
     ns: Optional[str]
     nsmap: Optional[NsMap]
-    nillable: bool
+    nillable: Optional[bool]
     wrapped: Optional['XmlEntityInfoP']
 
 
@@ -54,7 +54,7 @@ class XmlEntityInfo(pd.fields.FieldInfo):
             path: Optional[str] = None,
             ns: Optional[str] = None,
             nsmap: Optional[NsMap] = None,
-            nillable: bool = False,
+            nillable: Optional[bool] = None,
             wrapped: Optional[pd.fields.FieldInfo] = None,
             **kwargs: Any,
     ):
@@ -113,7 +113,7 @@ def element(
         tag: Optional[str] = None,
         ns: Optional[str] = None,
         nsmap: Optional[NsMap] = None,
-        nillable: bool = False,
+        nillable: Optional[bool] = None,
         *,
         default: Any = pdc.PydanticUndefined,
         default_factory: Optional[Callable[[], Any]] = _Unset,
@@ -179,7 +179,7 @@ class ComputedXmlEntityInfo(pd.fields.ComputedFieldInfo):
     path: Optional[str]
     ns: Optional[str]
     nsmap: Optional[NsMap]
-    nillable: bool
+    nillable: Optional[bool]
     wrapped: Optional[XmlEntityInfoP]  # to be compliant with XmlEntityInfoP protocol
 
     def __post_init__(self) -> None:
@@ -199,7 +199,7 @@ def computed_entity(
         path = kwargs.pop('path', None)
         ns = kwargs.pop('ns', None)
         nsmap = kwargs.pop('nsmap', None)
-        nillable = kwargs.pop('nillable', False)
+        nillable = kwargs.pop('nillable', None)
 
         descriptor_proxy = pd.computed_field(**kwargs)(prop)
         descriptor_proxy.decorator_info = ComputedXmlEntityInfo(
@@ -245,7 +245,7 @@ def computed_element(
         tag: Optional[str] = None,
         ns: Optional[str] = None,
         nsmap: Optional[NsMap] = None,
-        nillable: bool = False,
+        nillable: Optional[bool] = None,
         **kwargs: Any,
 ) -> Union[PropertyT, Callable[[PropertyT], PropertyT]]:
     """

--- a/pydantic_xml/fields.py
+++ b/pydantic_xml/fields.py
@@ -1,0 +1,310 @@
+import dataclasses as dc
+import typing
+from typing import Any, Callable, Optional, Type, TypeVar, Union
+
+import pydantic as pd
+import pydantic_core as pdc
+from pydantic._internal._model_construction import ModelMetaclass  # noqa
+from pydantic.root_model import _RootModelMetaclass as RootModelMetaclass  # noqa
+
+from . import config, model, utils
+from .element import XmlElementReader, XmlElementWriter
+from .typedefs import EntityLocation
+from .utils import NsMap
+
+__all__ = (
+    'attr',
+    'computed_attr',
+    'computed_element',
+    'computed_entity',
+    'element',
+    'wrapped',
+    'xml_field_serializer',
+    'xml_field_validator',
+    'ComputedXmlEntityInfo',
+    'SerializerFunc',
+    'ValidatorFunc',
+    'XmlEntityInfo',
+    'XmlEntityInfoP',
+    'XmlFieldSerializer',
+    'XmlFieldValidator',
+)
+
+
+class XmlEntityInfoP(typing.Protocol):
+    location: Optional[EntityLocation]
+    path: Optional[str]
+    ns: Optional[str]
+    nsmap: Optional[NsMap]
+    nillable: bool
+    wrapped: Optional['XmlEntityInfoP']
+
+
+class XmlEntityInfo(pd.fields.FieldInfo):
+    """
+    Field xml meta-information.
+    """
+
+    __slots__ = ('location', 'path', 'ns', 'nsmap', 'nillable', 'wrapped')
+
+    def __init__(
+            self,
+            location: Optional[EntityLocation],
+            /,
+            path: Optional[str] = None,
+            ns: Optional[str] = None,
+            nsmap: Optional[NsMap] = None,
+            nillable: bool = False,
+            wrapped: Optional[pd.fields.FieldInfo] = None,
+            **kwargs: Any,
+    ):
+        if wrapped is not None:
+            # copy arguments from the wrapped entity to let pydantic know how to process the field
+            for entity_field_name in utils.get_slots(wrapped):
+                kwargs[entity_field_name] = getattr(wrapped, entity_field_name)
+
+        if kwargs.get('serialization_alias') is None:
+            kwargs['serialization_alias'] = kwargs.get('alias')
+
+        if kwargs.get('validation_alias') is None:
+            kwargs['validation_alias'] = kwargs.get('alias')
+
+        super().__init__(**kwargs)
+        self.location = location
+        self.path = path
+        self.ns = ns
+        self.nsmap = nsmap
+        self.nillable = nillable
+        self.wrapped: Optional[XmlEntityInfoP] = wrapped if isinstance(wrapped, XmlEntityInfo) else None
+
+        if config.REGISTER_NS_PREFIXES and nsmap:
+            utils.register_nsmap(nsmap)
+
+
+_Unset: Any = pdc.PydanticUndefined
+
+
+def attr(
+        name: Optional[str] = None,
+        ns: Optional[str] = None,
+        *,
+        default: Any = pdc.PydanticUndefined,
+        default_factory: Optional[Callable[[], Any]] = _Unset,
+        **kwargs: Any,
+) -> Any:
+    """
+    Marks a pydantic field as an xml attribute.
+
+    :param name: attribute name
+    :param ns: attribute xml namespace
+    :param default: the default value of the field.
+    :param default_factory: the factory function used to construct the default for the field.
+    :param kwargs: pydantic field arguments. See :py:class:`pydantic.Field`
+    """
+
+    return XmlEntityInfo(
+        EntityLocation.ATTRIBUTE,
+        path=name, ns=ns, default=default, default_factory=default_factory,
+        **kwargs,
+    )
+
+
+def element(
+        tag: Optional[str] = None,
+        ns: Optional[str] = None,
+        nsmap: Optional[NsMap] = None,
+        nillable: bool = False,
+        *,
+        default: Any = pdc.PydanticUndefined,
+        default_factory: Optional[Callable[[], Any]] = _Unset,
+        **kwargs: Any,
+) -> Any:
+    """
+    Marks a pydantic field as an xml element.
+
+    :param tag: element tag
+    :param ns: element xml namespace
+    :param nsmap: element xml namespace map
+    :param nillable: is element nillable. See https://www.w3.org/TR/xmlschema-1/#xsi_nil.
+    :param default: the default value of the field.
+    :param default_factory: the factory function used to construct the default for the field.
+    :param kwargs: pydantic field arguments. See :py:class:`pydantic.Field`
+    """
+
+    return XmlEntityInfo(
+        EntityLocation.ELEMENT,
+        path=tag, ns=ns, nsmap=nsmap, nillable=nillable, default=default, default_factory=default_factory,
+        **kwargs,
+    )
+
+
+def wrapped(
+        path: str,
+        entity: Optional[pd.fields.FieldInfo] = None,
+        ns: Optional[str] = None,
+        nsmap: Optional[NsMap] = None,
+        *,
+        default: Any = pdc.PydanticUndefined,
+        default_factory: Optional[Callable[[], Any]] = _Unset,
+        **kwargs: Any,
+) -> Any:
+    """
+    Marks a pydantic field as a wrapped xml entity.
+
+    :param entity: wrapped entity
+    :param path: entity path
+    :param ns: element xml namespace
+    :param nsmap: element xml namespace map
+    :param default: the default value of the field.
+    :param default_factory: the factory function used to construct the default for the field.
+    :param kwargs: pydantic field arguments. See :py:class:`pydantic.Field`
+    """
+
+    return XmlEntityInfo(
+        EntityLocation.WRAPPED,
+        path=path, ns=ns, nsmap=nsmap, wrapped=entity, default=default, default_factory=default_factory,
+        **kwargs,
+    )
+
+
+@dc.dataclass
+class ComputedXmlEntityInfo(pd.fields.ComputedFieldInfo):
+    """
+    Computed field xml meta-information.
+    """
+
+    __slots__ = ('location', 'path', 'ns', 'nsmap', 'nillable', 'wrapped')
+
+    location: Optional[EntityLocation]
+    path: Optional[str]
+    ns: Optional[str]
+    nsmap: Optional[NsMap]
+    nillable: bool
+    wrapped: Optional[XmlEntityInfoP]  # to be compliant with XmlEntityInfoP protocol
+
+    def __post_init__(self) -> None:
+        if config.REGISTER_NS_PREFIXES and self.nsmap:
+            utils.register_nsmap(self.nsmap)
+
+
+PropertyT = typing.TypeVar('PropertyT')
+
+
+def computed_entity(
+        location: EntityLocation,
+        prop: Optional[PropertyT] = None,
+        **kwargs: Any,
+) -> Union[PropertyT, Callable[[PropertyT], PropertyT]]:
+    def decorator(prop: Any) -> Any:
+        path = kwargs.pop('path', None)
+        ns = kwargs.pop('ns', None)
+        nsmap = kwargs.pop('nsmap', None)
+        nillable = kwargs.pop('nillable', False)
+
+        descriptor_proxy = pd.computed_field(**kwargs)(prop)
+        descriptor_proxy.decorator_info = ComputedXmlEntityInfo(
+            location=location,
+            path=path,
+            ns=ns,
+            nsmap=nsmap,
+            nillable=nillable,
+            wrapped=None,
+            **dc.asdict(descriptor_proxy.decorator_info),
+        )
+
+        return descriptor_proxy
+
+    if prop is None:
+        return decorator
+    else:
+        return decorator(prop)
+
+
+def computed_attr(
+        prop: Optional[PropertyT] = None,
+        *,
+        name: Optional[str] = None,
+        ns: Optional[str] = None,
+        **kwargs: Any,
+) -> Union[PropertyT, Callable[[PropertyT], PropertyT]]:
+    """
+    Marks a property as an xml attribute.
+
+    :param prop: decorated property
+    :param name: attribute name
+    :param ns: attribute xml namespace
+    :param kwargs: pydantic computed field arguments. See :py:class:`pydantic.computed_field`
+    """
+
+    return computed_entity(EntityLocation.ATTRIBUTE, prop, path=name, ns=ns, **kwargs)
+
+
+def computed_element(
+        prop: Optional[PropertyT] = None,
+        *,
+        tag: Optional[str] = None,
+        ns: Optional[str] = None,
+        nsmap: Optional[NsMap] = None,
+        nillable: bool = False,
+        **kwargs: Any,
+) -> Union[PropertyT, Callable[[PropertyT], PropertyT]]:
+    """
+    Marks a property as an xml element.
+
+    :param prop: decorated property
+    :param tag: element tag
+    :param ns: element xml namespace
+    :param nsmap: element xml namespace map
+    :param nillable: is element nillable. See https://www.w3.org/TR/xmlschema-1/#xsi_nil.
+    :param kwargs: pydantic computed field arguments. See :py:class:`pydantic.computed_field`
+    """
+
+    return computed_entity(EntityLocation.ELEMENT, prop, path=tag, ns=ns, nsmap=nsmap, nillable=nillable, **kwargs)
+
+
+ValidatorFunc = Callable[[Type['model.BaseXmlModel'], XmlElementReader, str], Any]
+ValidatorFuncT = TypeVar('ValidatorFuncT', bound=ValidatorFunc)
+
+
+def xml_field_validator(field: str, /, *fields: str) -> Callable[[ValidatorFuncT], ValidatorFuncT]:
+    """
+    Marks the method as a field xml validator.
+
+    :param field: field to be validated
+    :param fields: fields to be validated
+    """
+
+    def wrapper(func: ValidatorFuncT) -> ValidatorFuncT:
+        setattr(func, '__xml_field_validator__', (field, *fields))
+        return func
+
+    return wrapper
+
+
+SerializerFunc = Callable[['model.BaseXmlModel', XmlElementWriter, Any, str], Any]
+SerializerFuncT = TypeVar('SerializerFuncT', bound=SerializerFunc)
+
+
+def xml_field_serializer(field: str, /, *fields: str) -> Callable[[SerializerFuncT], SerializerFuncT]:
+    """
+    Marks the method as a field xml serializer.
+
+    :param field: field to be serialized
+    :param fields: fields to be serialized
+    """
+
+    def wrapper(func: SerializerFuncT) -> SerializerFuncT:
+        setattr(func, '__xml_field_serializer__', (field, *fields))
+        return func
+
+    return wrapper
+
+
+@dc.dataclass(frozen=True)
+class XmlFieldValidator:
+    func: ValidatorFunc
+
+
+@dc.dataclass(frozen=True)
+class XmlFieldSerializer:
+    func: SerializerFunc

--- a/pydantic_xml/model.py
+++ b/pydantic_xml/model.py
@@ -1,6 +1,5 @@
-import dataclasses as dc
 import typing
-from typing import Any, Callable, ClassVar, Dict, Generic, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, ClassVar, Dict, Generic, Optional, Tuple, Type, TypeVar, Union
 
 import pydantic as pd
 import pydantic_core as pdc
@@ -10,249 +9,21 @@ from pydantic._internal._model_construction import ModelMetaclass  # noqa
 from pydantic.root_model import _RootModelMetaclass as RootModelMetaclass  # noqa
 
 from . import config, errors, utils
-from .element import SearchMode, XmlElementReader, XmlElementWriter
+from .element import SearchMode
 from .element.native import ElementT, XmlElement, etree
+from .fields import SerializerFunc, ValidatorFunc, XmlEntityInfo, XmlFieldSerializer, XmlFieldValidator, attr, element
+from .fields import wrapped
 from .serializers.factories.model import BaseModelSerializer
-from .serializers.serializer import Serializer, XmlEntityInfoP
+from .serializers.serializer import Serializer
 from .typedefs import EntityLocation
 from .utils import NsMap
 
 __all__ = (
-    'attr',
-    'create_model',
-    'element',
-    'wrapped',
-    'computed_attr',
-    'computed_element',
-    'xml_field_serializer',
-    'xml_field_validator',
-    'XmlFieldSerializer',
-    'XmlFieldValidator',
     'BaseXmlModel',
+    'create_model',
     'RootXmlModel',
+    'XmlModelMeta',
 )
-
-
-@dc.dataclass
-class ComputedXmlEntityInfo(pd.fields.ComputedFieldInfo):
-    """
-    Computed field xml meta-information.
-    """
-
-    __slots__ = ('location', 'path', 'ns', 'nsmap', 'nillable', 'wrapped')
-
-    location: Optional[EntityLocation]
-    path: Optional[str]
-    ns: Optional[str]
-    nsmap: Optional[NsMap]
-    nillable: bool
-    wrapped: Optional[XmlEntityInfoP]  # to be compliant with XmlEntityInfoP protocol
-
-    def __post_init__(self) -> None:
-        if config.REGISTER_NS_PREFIXES and self.nsmap:
-            utils.register_nsmap(self.nsmap)
-
-
-PropertyT = typing.TypeVar('PropertyT')
-
-
-def computed_entity(
-        location: EntityLocation,
-        prop: Optional[PropertyT] = None,
-        **kwargs: Any,
-) -> Union[PropertyT, Callable[[PropertyT], PropertyT]]:
-    def decorator(prop: Any) -> Any:
-        path = kwargs.pop('path', None)
-        ns = kwargs.pop('ns', None)
-        nsmap = kwargs.pop('nsmap', None)
-        nillable = kwargs.pop('nillable', False)
-
-        descriptor_proxy = pd.computed_field(**kwargs)(prop)
-        descriptor_proxy.decorator_info = ComputedXmlEntityInfo(
-            location=location,
-            path=path,
-            ns=ns,
-            nsmap=nsmap,
-            nillable=nillable,
-            wrapped=None,
-            **dc.asdict(descriptor_proxy.decorator_info),
-        )
-
-        return descriptor_proxy
-
-    if prop is None:
-        return decorator
-    else:
-        return decorator(prop)
-
-
-def computed_attr(
-        prop: Optional[PropertyT] = None,
-        *,
-        name: Optional[str] = None,
-        ns: Optional[str] = None,
-        **kwargs: Any,
-) -> Union[PropertyT, Callable[[PropertyT], PropertyT]]:
-    """
-    Marks a property as an xml attribute.
-
-    :param prop: decorated property
-    :param name: attribute name
-    :param ns: attribute xml namespace
-    :param kwargs: pydantic computed field arguments. See :py:class:`pydantic.computed_field`
-    """
-
-    return computed_entity(EntityLocation.ATTRIBUTE, prop, path=name, ns=ns, **kwargs)
-
-
-def computed_element(
-        prop: Optional[PropertyT] = None,
-        *,
-        tag: Optional[str] = None,
-        ns: Optional[str] = None,
-        nsmap: Optional[NsMap] = None,
-        nillable: bool = False,
-        **kwargs: Any,
-) -> Union[PropertyT, Callable[[PropertyT], PropertyT]]:
-    """
-    Marks a property as an xml element.
-
-    :param prop: decorated property
-    :param tag: element tag
-    :param ns: element xml namespace
-    :param nsmap: element xml namespace map
-    :param nillable: is element nillable. See https://www.w3.org/TR/xmlschema-1/#xsi_nil.
-    :param kwargs: pydantic computed field arguments. See :py:class:`pydantic.computed_field`
-    """
-
-    return computed_entity(EntityLocation.ELEMENT, prop, path=tag, ns=ns, nsmap=nsmap, nillable=nillable, **kwargs)
-
-
-class XmlEntityInfo(pd.fields.FieldInfo):
-    """
-    Field xml meta-information.
-    """
-
-    __slots__ = ('location', 'path', 'ns', 'nsmap', 'nillable', 'wrapped')
-
-    def __init__(
-            self,
-            location: Optional[EntityLocation],
-            /,
-            path: Optional[str] = None,
-            ns: Optional[str] = None,
-            nsmap: Optional[NsMap] = None,
-            nillable: bool = False,
-            wrapped: Optional[pd.fields.FieldInfo] = None,
-            **kwargs: Any,
-    ):
-        if wrapped is not None:
-            # copy arguments from the wrapped entity to let pydantic know how to process the field
-            for entity_field_name in utils.get_slots(wrapped):
-                kwargs[entity_field_name] = getattr(wrapped, entity_field_name)
-
-        if kwargs.get('serialization_alias') is None:
-            kwargs['serialization_alias'] = kwargs.get('alias')
-
-        if kwargs.get('validation_alias') is None:
-            kwargs['validation_alias'] = kwargs.get('alias')
-
-        super().__init__(**kwargs)
-        self.location = location
-        self.path = path
-        self.ns = ns
-        self.nsmap = nsmap
-        self.nillable = nillable
-        self.wrapped: Optional[XmlEntityInfoP] = wrapped if isinstance(wrapped, XmlEntityInfo) else None
-
-        if config.REGISTER_NS_PREFIXES and nsmap:
-            utils.register_nsmap(nsmap)
-
-
-_Unset: Any = pdc.PydanticUndefined
-
-
-def attr(
-        name: Optional[str] = None,
-        ns: Optional[str] = None,
-        *,
-        default: Any = pdc.PydanticUndefined,
-        default_factory: Optional[Callable[[], Any]] = _Unset,
-        **kwargs: Any,
-) -> Any:
-    """
-    Marks a pydantic field as an xml attribute.
-
-    :param name: attribute name
-    :param ns: attribute xml namespace
-    :param default: the default value of the field.
-    :param default_factory: the factory function used to construct the default for the field.
-    :param kwargs: pydantic field arguments. See :py:class:`pydantic.Field`
-    """
-
-    return XmlEntityInfo(
-        EntityLocation.ATTRIBUTE,
-        path=name, ns=ns, default=default, default_factory=default_factory,
-        **kwargs,
-    )
-
-
-def element(
-        tag: Optional[str] = None,
-        ns: Optional[str] = None,
-        nsmap: Optional[NsMap] = None,
-        nillable: bool = False,
-        *,
-        default: Any = pdc.PydanticUndefined,
-        default_factory: Optional[Callable[[], Any]] = _Unset,
-        **kwargs: Any,
-) -> Any:
-    """
-    Marks a pydantic field as an xml element.
-
-    :param tag: element tag
-    :param ns: element xml namespace
-    :param nsmap: element xml namespace map
-    :param nillable: is element nillable. See https://www.w3.org/TR/xmlschema-1/#xsi_nil.
-    :param default: the default value of the field.
-    :param default_factory: the factory function used to construct the default for the field.
-    :param kwargs: pydantic field arguments. See :py:class:`pydantic.Field`
-    """
-
-    return XmlEntityInfo(
-        EntityLocation.ELEMENT,
-        path=tag, ns=ns, nsmap=nsmap, nillable=nillable, default=default, default_factory=default_factory,
-        **kwargs,
-    )
-
-
-def wrapped(
-        path: str,
-        entity: Optional[pd.fields.FieldInfo] = None,
-        ns: Optional[str] = None,
-        nsmap: Optional[NsMap] = None,
-        *,
-        default: Any = pdc.PydanticUndefined,
-        default_factory: Optional[Callable[[], Any]] = _Unset,
-        **kwargs: Any,
-) -> Any:
-    """
-    Marks a pydantic field as a wrapped xml entity.
-
-    :param entity: wrapped entity
-    :param path: entity path
-    :param ns: element xml namespace
-    :param nsmap: element xml namespace map
-    :param default: the default value of the field.
-    :param default_factory: the factory function used to construct the default for the field.
-    :param kwargs: pydantic field arguments. See :py:class:`pydantic.Field`
-    """
-
-    return XmlEntityInfo(
-        EntityLocation.WRAPPED,
-        path=path, ns=ns, nsmap=nsmap, wrapped=entity, default=default, default_factory=default_factory,
-        **kwargs,
-    )
 
 
 Model = TypeVar('Model', bound='BaseXmlModel')
@@ -317,54 +88,6 @@ def create_model(
     model = pd.create_model(__model_name, __base__=model_base, **kwargs)
 
     return typing.cast(Type[Model], model)
-
-
-ValidatorFunc = Callable[[Type['BaseXmlModel'], XmlElementReader, str], Any]
-ValidatorFuncT = TypeVar('ValidatorFuncT', bound=ValidatorFunc)
-
-
-def xml_field_validator(field: str, /, *fields: str) -> Callable[[ValidatorFuncT], ValidatorFuncT]:
-    """
-    Marks the method as a field xml validator.
-
-    :param field: field to be validated
-    :param fields: fields to be validated
-    """
-
-    def wrapper(func: ValidatorFuncT) -> ValidatorFuncT:
-        setattr(func, '__xml_field_validator__', (field, *fields))
-        return func
-
-    return wrapper
-
-
-SerializerFunc = Callable[['BaseXmlModel', XmlElementWriter, Any, str], Any]
-SerializerFuncT = TypeVar('SerializerFuncT', bound=SerializerFunc)
-
-
-def xml_field_serializer(field: str, /, *fields: str) -> Callable[[SerializerFuncT], SerializerFuncT]:
-    """
-    Marks the method as a field xml serializer.
-
-    :param field: field to be serialized
-    :param fields: fields to be serialized
-    """
-
-    def wrapper(func: SerializerFuncT) -> SerializerFuncT:
-        setattr(func, '__xml_field_serializer__', (field, *fields))
-        return func
-
-    return wrapper
-
-
-@dc.dataclass(frozen=True)
-class XmlFieldValidator:
-    func: ValidatorFunc
-
-
-@dc.dataclass(frozen=True)
-class XmlFieldSerializer:
-    func: SerializerFunc
 
 
 @te.dataclass_transform(kw_only_default=True, field_specifiers=(attr, element, wrapped, pd.Field))

--- a/pydantic_xml/serializers/factories/model.py
+++ b/pydantic_xml/serializers/factories/model.py
@@ -9,7 +9,8 @@ from pydantic_core import core_schema as pcs
 import pydantic_xml as pxml
 from pydantic_xml import errors, utils
 from pydantic_xml.element import XmlElementReader, XmlElementWriter, is_element_nill, make_element_nill
-from pydantic_xml.serializers.serializer import SearchMode, Serializer, XmlEntityInfoP
+from pydantic_xml.fields import ComputedXmlEntityInfo, XmlEntityInfoP
+from pydantic_xml.serializers.serializer import SearchMode, Serializer
 from pydantic_xml.typedefs import EntityLocation, Location, NsMap
 from pydantic_xml.utils import QName, merge_nsmaps, select_ns
 
@@ -95,7 +96,7 @@ class ModelSerializer(BaseModelSerializer):
             field_alias = model_field.get('alias')
 
             computed_field_info = model_cls.__pydantic_decorators__.computed_fields[field_name].info
-            if isinstance(computed_field_info, pxml.model.ComputedXmlEntityInfo):
+            if isinstance(computed_field_info, ComputedXmlEntityInfo):
                 entity_info = computed_field_info
             else:
                 entity_info = None

--- a/pydantic_xml/serializers/factories/model.py
+++ b/pydantic_xml/serializers/factories/model.py
@@ -357,7 +357,7 @@ class ModelProxySerializer(BaseModelSerializer):
             nsmap: Optional[NsMap],
             search_mode: SearchMode,
             computed: bool,
-            nillable: bool,
+            nillable: Optional[bool],
     ):
         self._model = model
         self._element_name = QName.from_alias(tag=name, ns=ns, nsmap=nsmap).uri

--- a/pydantic_xml/serializers/factories/primitive.py
+++ b/pydantic_xml/serializers/factories/primitive.py
@@ -36,7 +36,7 @@ class TextSerializer(Serializer):
 
         return cls(computed, nillable)
 
-    def __init__(self, computed: bool, nillable: bool):
+    def __init__(self, computed: bool, nillable: Optional[bool]):
         self._computed = computed
         self._nillable = nillable
 
@@ -163,7 +163,7 @@ class ElementSerializer(TextSerializer):
             nsmap: Optional[NsMap],
             search_mode: SearchMode,
             computed: bool,
-            nillable: bool,
+            nillable: Optional[bool],
     ):
         super().__init__(computed, nillable)
 

--- a/pydantic_xml/serializers/serializer.py
+++ b/pydantic_xml/serializers/serializer.py
@@ -10,6 +10,7 @@ from pydantic_core import core_schema as pcs
 
 from pydantic_xml.element import SearchMode, XmlElementReader, XmlElementWriter
 from pydantic_xml.errors import ModelError
+from pydantic_xml.fields import XmlEntityInfoP
 from pydantic_xml.typedefs import EntityLocation, Location, NsMap
 from pydantic_xml.utils import select_ns
 
@@ -93,15 +94,6 @@ TYPE_FAMILY = {
 }
 
 
-class XmlEntityInfoP(typing.Protocol):
-    location: Optional[EntityLocation]
-    path: Optional[str]
-    ns: Optional[str]
-    nsmap: Optional[NsMap]
-    nillable: bool
-    wrapped: Optional['XmlEntityInfoP']
-
-
 class Serializer(abc.ABC):
     @dc.dataclass(frozen=True)
     class Context:
@@ -145,7 +137,7 @@ class Serializer(abc.ABC):
             return self.entity_info.nillable if self.entity_info is not None else False
 
         @property
-        def entity_wrapped(self) -> Optional['XmlEntityInfoP']:
+        def entity_wrapped(self) -> Optional[XmlEntityInfoP]:
             return self.entity_info.wrapped if self.entity_info is not None else None
 
         @cached_property

--- a/pydantic_xml/serializers/serializer.py
+++ b/pydantic_xml/serializers/serializer.py
@@ -133,7 +133,7 @@ class Serializer(abc.ABC):
             return self.entity_info.nsmap if self.entity_info is not None else None
 
         @property
-        def nillable(self) -> bool:
+        def nillable(self) -> Optional[bool]:
             return self.entity_info.nillable if self.entity_info is not None else False
 
         @property


### PR DESCRIPTION
Adds support for multiple field type annotations.

See the following example:

```python
from typing import Annotated

import pydantic_xml as pxml
from annotated_types import Ge, Le


CompanyElement = pxml.element(ns='co', nsmap={'co': 'http://company-ns.com'})


class Company(pxml.BaseXmlModel, tag='Company'):
    founded: Annotated[int, Ge(ge=0), Le(le=2025), CompanyElement] = pxml.element(tag='foundYear')


xml = '''
<Company xmlns:co="http://company-ns.com">
    <co:foundYear>2020</co:foundYear>
</Company>
'''

print(Company.from_xml(xml))
```

Fixes the [issue](https://github.com/dapper91/pydantic-xml/issues/266)