### PR TITLE
Allow attributes to be collections

### DIFF
--- a/pydantic_xml/serializers/factories/heterogeneous.py
+++ b/pydantic_xml/serializers/factories/heterogeneous.py
@@ -5,6 +5,7 @@ from pydantic_core import core_schema as pcs
 
 from pydantic_xml import errors, utils
 from pydantic_xml.element import XmlElementReader, XmlElementWriter
+from pydantic_xml.serializers.factories import primitive
 from pydantic_xml.serializers.serializer import TYPE_FAMILY, SchemaTypeFamily, Serializer
 from pydantic_xml.typedefs import EntityLocation, Location
 
@@ -109,6 +110,6 @@ def from_core_schema(schema: pcs.TupleSchema, ctx: Serializer.Context) -> Serial
     elif ctx.entity_location is None:
         return ElementSerializer.from_core_schema(schema, ctx)
     elif ctx.entity_location is EntityLocation.ATTRIBUTE:
-        raise errors.ModelFieldError(ctx.model_name, ctx.field_name, "attributes of collection types are not supported")
+        return primitive.from_core_schema(pcs.StringSchema(type="str"), ctx)
     else:
         raise AssertionError("unreachable")

--- a/pydantic_xml/serializers/factories/homogeneous.py
+++ b/pydantic_xml/serializers/factories/homogeneous.py
@@ -6,6 +6,7 @@ from pydantic_core import core_schema as pcs
 
 from pydantic_xml import errors, utils
 from pydantic_xml.element import XmlElementReader, XmlElementWriter
+from pydantic_xml.serializers.factories import primitive
 from pydantic_xml.serializers.serializer import TYPE_FAMILY, SchemaTypeFamily, Serializer
 from pydantic_xml.typedefs import EntityLocation, Location
 
@@ -27,7 +28,6 @@ class ElementSerializer(Serializer):
         if isinstance(items_schema, list):
             assert len(items_schema) == 1, "unexpected items schema type"
             items_schema = items_schema[0]
-
         inner_serializer = Serializer.parse_core_schema(items_schema, ctx)
 
         return cls(model_name, computed, inner_serializer)
@@ -134,6 +134,6 @@ def from_core_schema(schema: HomogeneousCollectionTypeSchema, ctx: Serializer.Co
     elif ctx.entity_location is None:
         return ElementSerializer.from_core_schema(schema, ctx)
     elif ctx.entity_location is EntityLocation.ATTRIBUTE:
-        raise errors.ModelFieldError(ctx.model_name, ctx.field_name, "attributes of collection types are not supported")
+        return primitive.from_core_schema(pcs.StringSchema(type="str"), ctx)
     else:
         raise AssertionError("unreachable")


### PR DESCRIPTION
Currently collection types are not allowed for attributes. This is logical for the default serializers, but the user might overwrite default behavior with a custom validator that might return a collection. For example:

```python
from typing import Annotated, Any
import pydantic_xml as pxml
from pydantic import BeforeValidator
from pydantic.functional_serializers import PlainSerializer

def validate_space_separated_attr(value: str) -> list[str]:  
    return value.split(" ")

def serialize_space_separated_attr(values: list[Any]) -> str:  
    return " ".join(str(x) for x in values)

SpaceSeparatedValueListAttr = Annotated[list[str], BeforeValidator(validate_space_separated_attr), PlainSerializer(serialize_space_separated_attr)]
 
class Person(pxml.BaseXmlModel):
    children: SpaceSeparatedValueListAttr = pxml.attr()
    name: str = pxml.element()
    
doc = """
<Person children="Bob Eve">
  <name>Alice</name>
</Person>
"""
    
alice = Person.from_xml(doc)
print(alice.children) # prints ['Bob', 'Eve']
print(alice.to_xml())
```


Instead of disallowing outright, this change parses these attributes as a string and leave it up to the user.
This might not be a good final solution, it would be nicer to check if a custom validator logic is present and error when it is not.
However, I do not see an easy way to add such a check. 

What do you think? I at least got stuck parsing XML documents that contain space-separated lists in attributes.