### PR TITLE
typing fix

### DIFF
--- a/pydantic_xml/fields.py
+++ b/pydantic_xml/fields.py
@@ -1,6 +1,6 @@
 import dataclasses as dc
 import typing
-from typing import Any, Callable, Optional, Type, TypeVar, Union
+from typing import Any, Callable, Optional, TypeVar, Union
 
 import pydantic as pd
 import pydantic_core as pdc
@@ -8,7 +8,6 @@ from pydantic._internal._model_construction import ModelMetaclass  # noqa
 from pydantic.root_model import _RootModelMetaclass as RootModelMetaclass  # noqa
 
 from . import config, model, utils
-from .element import XmlElementReader, XmlElementWriter
 from .typedefs import EntityLocation
 from .utils import NsMap
 
@@ -22,8 +21,6 @@ __all__ = (
     'xml_field_serializer',
     'xml_field_validator',
     'ComputedXmlEntityInfo',
-    'SerializerFunc',
-    'ValidatorFunc',
     'XmlEntityInfo',
     'XmlEntityInfoP',
     'XmlFieldSerializer',
@@ -295,8 +292,7 @@ def computed_element(
     return computed_entity(EntityLocation.ELEMENT, prop, path=tag, ns=ns, nsmap=nsmap, nillable=nillable, **kwargs)
 
 
-ValidatorFunc = Callable[[Type['model.BaseXmlModel'], XmlElementReader, str], Any]
-ValidatorFuncT = TypeVar('ValidatorFuncT', bound=ValidatorFunc)
+ValidatorFuncT = TypeVar('ValidatorFuncT', bound='model.SerializerFunc')
 
 
 def xml_field_validator(field: str, /, *fields: str) -> Callable[[ValidatorFuncT], ValidatorFuncT]:
@@ -314,8 +310,7 @@ def xml_field_validator(field: str, /, *fields: str) -> Callable[[ValidatorFuncT
     return wrapper
 
 
-SerializerFunc = Callable[['model.BaseXmlModel', XmlElementWriter, Any, str], Any]
-SerializerFuncT = TypeVar('SerializerFuncT', bound=SerializerFunc)
+SerializerFuncT = TypeVar('SerializerFuncT', bound='model.SerializerFunc')
 
 
 def xml_field_serializer(field: str, /, *fields: str) -> Callable[[SerializerFuncT], SerializerFuncT]:
@@ -335,9 +330,9 @@ def xml_field_serializer(field: str, /, *fields: str) -> Callable[[SerializerFun
 
 @dc.dataclass(frozen=True)
 class XmlFieldValidator:
-    func: ValidatorFunc
+    func: 'model.ValidatorFunc'
 
 
 @dc.dataclass(frozen=True)
 class XmlFieldSerializer:
-    func: SerializerFunc
+    func: 'model.SerializerFunc'

--- a/pydantic_xml/model.py
+++ b/pydantic_xml/model.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Any, ClassVar, Dict, Generic, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, Callable, ClassVar, Dict, Generic, Optional, Tuple, Type, TypeVar, Union
 
 import pydantic as pd
 import pydantic_core as pdc
@@ -9,10 +9,9 @@ from pydantic._internal._model_construction import ModelMetaclass  # noqa
 from pydantic.root_model import _RootModelMetaclass as RootModelMetaclass  # noqa
 
 from . import config, errors, utils
-from .element import SearchMode
+from .element import SearchMode, XmlElementReader, XmlElementWriter
 from .element.native import ElementT, XmlElement, etree
-from .fields import SerializerFunc, ValidatorFunc, XmlEntityInfo, XmlFieldSerializer, XmlFieldValidator, attr, element
-from .fields import wrapped
+from .fields import XmlEntityInfo, XmlFieldSerializer, XmlFieldValidator, attr, element, wrapped
 from .serializers.factories.model import BaseModelSerializer
 from .serializers.serializer import Serializer
 from .typedefs import EntityLocation
@@ -22,6 +21,8 @@ __all__ = (
     'BaseXmlModel',
     'create_model',
     'RootXmlModel',
+    'SerializerFunc',
+    'ValidatorFunc',
     'XmlModelMeta',
 )
 
@@ -136,6 +137,8 @@ class XmlModelMeta(ModelMetaclass):
                         cls.__xml_field_validators__[field] = func
 
 
+ValidatorFunc = Callable[[Type['BaseXmlModel'], XmlElementReader, str], Any]
+SerializerFunc = Callable[['BaseXmlModel', XmlElementWriter, Any, str], Any]
 ModelT = TypeVar('ModelT', bound='BaseXmlModel')
 
 


### PR DESCRIPTION
- func type aliases moved to `model` module to make `get_type_hints` work correctly.

fixes the [issue](https://github.com/dapper91/pydantic-xml/issues/271) 