### PR TITLE
Fix type annotations for xml_field_validator/serializer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Run tests (std)
       run: PYTHONPATH="$(pwd):$PYTHONPATH" FORCE_STD_XML=true poetry run py.test --cov=pydantic_xml --cov-report=xml tests
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml

--- a/examples/xml-serialization-decorator/model.py
+++ b/examples/xml-serialization-decorator/model.py
@@ -11,9 +11,12 @@ class Plot(BaseXmlModel):
     y: List[float] = element()
 
     @xml_field_validator('x', 'y')
+    @classmethod
     def validate_space_separated_list(cls, element: XmlElementReader, field_name: str) -> List[float]:
-        if element := element.pop_element(field_name, search_mode=cls.__xml_search_mode__):
-            return list(map(float, element.pop_text().split()))
+        if (sub_element := element.pop_element(field_name, search_mode=cls.__xml_search_mode__)) and (
+            text := sub_element.pop_text()
+        ):
+            return list(map(float, text.split()))
 
         return []
 

--- a/pydantic_xml/fields.py
+++ b/pydantic_xml/fields.py
@@ -1,6 +1,6 @@
 import dataclasses as dc
 import typing
-from typing import Any, Callable, Optional, TypeVar, Union
+from typing import Any, Callable, Optional, Union
 
 import pydantic as pd
 import pydantic_core as pdc
@@ -292,10 +292,9 @@ def computed_element(
     return computed_entity(EntityLocation.ELEMENT, prop, path=tag, ns=ns, nsmap=nsmap, nillable=nillable, **kwargs)
 
 
-ValidatorFuncT = TypeVar('ValidatorFuncT', bound='model.SerializerFunc')
-
-
-def xml_field_validator(field: str, /, *fields: str) -> Callable[[ValidatorFuncT], ValidatorFuncT]:
+def xml_field_validator(
+    field: str, /, *fields: str
+) -> 'Callable[[model.ValidatorFuncT[model.ModelT]], model.ValidatorFuncT[model.ModelT]]':
     """
     Marks the method as a field xml validator.
 
@@ -303,17 +302,18 @@ def xml_field_validator(field: str, /, *fields: str) -> Callable[[ValidatorFuncT
     :param fields: fields to be validated
     """
 
-    def wrapper(func: ValidatorFuncT) -> ValidatorFuncT:
+    def wrapper(func: model.ValidatorFuncT[model.ModelT]) -> model.ValidatorFuncT[model.ModelT]:
+        if isinstance(func, (classmethod, staticmethod)):
+            func = func.__func__
         setattr(func, '__xml_field_validator__', (field, *fields))
         return func
 
     return wrapper
 
 
-SerializerFuncT = TypeVar('SerializerFuncT', bound='model.SerializerFunc')
-
-
-def xml_field_serializer(field: str, /, *fields: str) -> Callable[[SerializerFuncT], SerializerFuncT]:
+def xml_field_serializer(
+    field: str, /, *fields: str
+) -> 'Callable[[model.SerializerFuncT[model.ModelT]], model.SerializerFuncT[model.ModelT]]':
     """
     Marks the method as a field xml serializer.
 
@@ -321,7 +321,7 @@ def xml_field_serializer(field: str, /, *fields: str) -> Callable[[SerializerFun
     :param fields: fields to be serialized
     """
 
-    def wrapper(func: SerializerFuncT) -> SerializerFuncT:
+    def wrapper(func: model.SerializerFuncT[model.ModelT]) -> model.SerializerFuncT[model.ModelT]:
         setattr(func, '__xml_field_serializer__', (field, *fields))
         return func
 

--- a/pydantic_xml/model.py
+++ b/pydantic_xml/model.py
@@ -20,9 +20,12 @@ from .utils import NsMap
 __all__ = (
     'BaseXmlModel',
     'create_model',
+    'ModelT',
     'RootXmlModel',
     'SerializerFunc',
+    'SerializerFuncT',
     'ValidatorFunc',
+    'ValidatorFuncT',
     'XmlModelMeta',
 )
 
@@ -137,9 +140,11 @@ class XmlModelMeta(ModelMetaclass):
                         cls.__xml_field_validators__[field] = func
 
 
-ValidatorFunc = Callable[[Type['BaseXmlModel'], XmlElementReader, str], Any]
-SerializerFunc = Callable[['BaseXmlModel', XmlElementWriter, Any, str], Any]
 ModelT = TypeVar('ModelT', bound='BaseXmlModel')
+ValidatorFuncT = Callable[[Type[ModelT], XmlElementReader, str], Any]
+ValidatorFunc = ValidatorFuncT['BaseXmlModel']
+SerializerFuncT = Callable[[ModelT, XmlElementWriter, Any, str], Any]
+SerializerFunc = SerializerFuncT['BaseXmlModel']
 
 
 class BaseXmlModel(BaseModel, __xml_abstract__=True, metaclass=XmlModelMeta):

--- a/tests/test_preprocessors.py
+++ b/tests/test_preprocessors.py
@@ -13,9 +13,12 @@ def test_xml_field_validator():
         element1: List[int] = element()
 
         @xml_field_validator('element1')
+        @classmethod
         def validate_element(cls, element: XmlElementReader, field_name: str) -> List[int]:
-            if element := element.pop_element(field_name, search_mode=cls.__xml_search_mode__):
-                return list(map(int, element.pop_text().split()))
+            if (sub_element := element.pop_element(field_name, search_mode=cls.__xml_search_mode__)) and (
+                text := sub_element.pop_text()
+            ):
+                return list(map(float, text.split()))
 
             return []
 


### PR DESCRIPTION
There are 2 issues with the annotations:

1. Function types are contravariant rather than covariant in their argument types. This means that `Callable[[BaseXmlModel], Any]` is a subtype rather than a supertype of `Callable[[MyModel], Any]` and so using `Callable[[BaseXmlModel], Any]` as a lower bound of TypeVars doesn't work. Since Python doesn't support upper bounds on TypeVars, the solution is to push the TypeVar inside. To see the issue run mypy on the example from the documentation[1]. Currently, you get these errors:

   ```
   t.py:13: error: Value of type variable "ValidatorFuncT" of function cannot be "Callable[[type[Plot], XmlElementReader, str], list[float]]"  [type-var]
   t.py:21: error: Value of type variable "SerializerFuncT" of function cannot be "Callable[[Plot, XmlElementWriter, list[float], str], None]"  [type-var]
   ```

   This PR resolves these (however, validate_space_separated_list needs to be decorated with `@classmethod`).

2. A recent commit[2] has a typo where ValidatorFuncT was bound by SerializerFunc instead of ValidatorFunc.

[1] https://pydantic-xml.readthedocs.io/en/latest/pages/misc.html#custom-xml-serialization
[2] https://github.com/dapper91/pydantic-xml/commit/ec4b547340b34fec395f036256eeb1e648cfee98