### PR TITLE
fix: pydantic 2.12 compatibility.

### DIFF
--- a/pydantic_xml/compat.py
+++ b/pydantic_xml/compat.py
@@ -1,0 +1,16 @@
+"""
+pydantic compatibility module.
+"""
+
+import pydantic as pd
+from pydantic._internal._model_construction import ModelMetaclass  # noqa
+from pydantic.root_model import _RootModelMetaclass as RootModelMetaclass  # noqa
+
+PYDANTIC_VERSION = tuple(map(int, pd.__version__.partition('+')[0].split('.')))
+
+
+def merge_field_infos(*field_infos: pd.fields.FieldInfo) -> pd.fields.FieldInfo:
+    if PYDANTIC_VERSION >= (2, 12, 0):
+        return pd.fields.FieldInfo._construct(field_infos)  # type: ignore[attr-defined]
+    else:
+        return pd.fields.FieldInfo.merge_field_infos(*field_infos)

--- a/pydantic_xml/model.py
+++ b/pydantic_xml/model.py
@@ -5,10 +5,9 @@ import pydantic as pd
 import pydantic_core as pdc
 import typing_extensions as te
 from pydantic import BaseModel, RootModel
-from pydantic._internal._model_construction import ModelMetaclass  # noqa
-from pydantic.root_model import _RootModelMetaclass as RootModelMetaclass  # noqa
 
 from . import config, errors, utils
+from .compat import ModelMetaclass, RootModelMetaclass
 from .element import SearchMode, XmlElementReader, XmlElementWriter
 from .element.native import ElementT, XmlElement, etree
 from .fields import XmlEntityInfo, XmlFieldSerializer, XmlFieldValidator, attr, element, wrapped

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -282,9 +282,9 @@ def test_model_validator():
             }
 
         @model_validator(mode='after')
-        def validate_model_after(cls, obj: 'TestModel') -> 'TestModel':
-            obj.field1 = obj.field1.replace(tzinfo=dt.timezone.utc)
-            return obj
+        def validate_model_after(self) -> 'TestModel':
+            self.field1 = self.field1.replace(tzinfo=dt.timezone.utc)
+            return self
 
         @model_validator(mode='wrap')
         def validate_model_wrap(cls, obj: 'TestModel', handler: Callable) -> 'TestModel':

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -6,7 +6,6 @@ import pytest
 from helpers import assert_xml_equal
 
 from pydantic_xml import BaseXmlModel, RootXmlModel, attr, element, errors, wrapped
-from pydantic_xml.fields import XmlEntityInfo
 
 
 def test_xml_declaration():
@@ -385,27 +384,24 @@ def test_pydantic_validation_context():
 def test_field_info_merge():
     from typing import Annotated
 
-    from annotated_types import Ge, Lt
-
     class TestModel(BaseXmlModel, tag='root'):
         element1: Annotated[
             int,
             pd.Field(ge=0),
             pd.Field(default=0, lt=100),
-            element(nillable=True),
-        ] = element(tag='elm', lt=10)
+            element(lt=5),
+        ] = element(tag='elm')
 
     field_info = TestModel.model_fields['element1']
-    assert isinstance(field_info, XmlEntityInfo)
-    assert field_info.metadata == [Ge(ge=0), Lt(lt=10)]
     assert field_info.default == 0
-    assert field_info.nillable == True
-    assert field_info.path == 'elm'
 
     TestModel.from_xml("<root><elm>0</elm></root>")
 
     with pytest.raises(pd.ValidationError):
         TestModel.from_xml("<root><elm>-1</elm></root>")
+
+    with pytest.raises(pd.ValidationError):
+        TestModel.from_xml("<root><elm>5</elm></root>")
 
 
 def test_get_type_hints():


### PR DESCRIPTION
Due to pydantic 2.12 breaking changes `FieldInfo` can not be inherited anymore, `FieldInfo.merge_field_infos` is depricated. 

The fix get rid of `XmlEntityInfo` inheritance from `FieldInfo` and uses `FieldInfo` metadata as an xml meta-information storage.

Fixes the issue https://github.com/dapper91/pydantic-xml/issues/293 and https://github.com/dapper91/pydantic-xml/issues/292