### PR TITLE
Support `extra="allow"` for real

### DIFF
--- a/pydantic_xml/model.py
+++ b/pydantic_xml/model.py
@@ -304,12 +304,13 @@ class BaseXmlModel(BaseModel, __xml_abstract__=True, metaclass=XmlModelMeta):
         assert self.__xml_serializer__ is not None, f"model {type(self).__name__} is partially initialized"
 
         root = XmlElement(tag=self.__xml_serializer__.element_name, nsmap=self.__xml_serializer__.nsmap)
+        encoded = pdc.to_jsonable_python(
+            self,
+            by_alias=False,
+            fallback=lambda obj: obj if not isinstance(obj, ElementT) else None,  # for raw fields support
+        )
         self.__xml_serializer__.serialize(
-            root, self, pdc.to_jsonable_python(
-                self,
-                by_alias=False,
-                fallback=lambda obj: obj if not isinstance(obj, ElementT) else None,  # for raw fields support
-            ),
+            root, self, encoded,
             skip_empty=skip_empty,
             exclude_none=exclude_none,
             exclude_unset=exclude_unset,

--- a/pydantic_xml/serializers/factories/model.py
+++ b/pydantic_xml/serializers/factories/model.py
@@ -10,6 +10,7 @@ import pydantic_xml as pxml
 from pydantic_xml import errors, utils
 from pydantic_xml.element import XmlElementReader, XmlElementWriter, is_element_nill, make_element_nill
 from pydantic_xml.fields import ComputedXmlEntityInfo, XmlEntityInfoP, extract_field_xml_entity_info
+from pydantic_xml.serializers.factories.primitive import AttributeSerializer
 from pydantic_xml.serializers.serializer import SearchMode, Serializer
 from pydantic_xml.typedefs import EntityLocation, Location, NsMap
 from pydantic_xml.utils import QName, merge_nsmaps, select_ns
@@ -50,6 +51,20 @@ class BaseModelSerializer(Serializer, abc.ABC):
 
         if line_errors:
             raise pd.ValidationError.from_exception_data(title=error_title, line_errors=line_errors)
+
+    @classmethod
+    def _keep_extra(cls, element: XmlElementReader) -> Dict:
+        result = {}
+        for path, attr, value in element.get_unbound():
+            if path:
+                first_tag = path[0].tag
+                # result_section = result.setdefault(first_tag, [])
+                # result_section.append(path)
+                result[first_tag] = []
+            elif attr:
+                result[attr] = value
+
+        return result
 
 
 class ModelSerializer(BaseModelSerializer):
@@ -163,7 +178,15 @@ class ModelSerializer(BaseModelSerializer):
         if self._model.__xml_skip_empty__ is not None:
             skip_empty = self._model.__xml_skip_empty__
 
-        for field_name, field_serializer in self._field_serializers.items():
+        all_fields = list(self._field_serializers.keys())
+        all_fields += [k for k in encoded.keys() if k not in all_fields]
+        # ^ avoid sets to preserve order of fields
+
+        for field_name in all_fields:
+            field_serializer = self._field_serializers.get(field_name, None)
+            if field_serializer is None:  # Probably from an `extra` field
+                field_serializer = AttributeSerializer(field_name, ns=None, nsmap=None, computed=False)
+
             if field_name in self._fields_serialization_exclude:
                 continue
             if exclude_unset and field_name not in value.__pydantic_fields_set__:
@@ -212,8 +235,13 @@ class ModelSerializer(BaseModelSerializer):
         if field_errors:
             raise utils.into_validation_error(title=self._model.__name__, errors_map=field_errors)
 
-        if self._model.model_config.get('extra', 'ignore') == 'forbid':
+        config_extra = self._model.model_config.get('extra', 'ignore')
+        if config_extra == 'forbid':
             self._check_extra(self._model.__name__, element)
+        elif config_extra == 'allow':
+            result.update(
+                self._keep_extra(element)
+            )
 
         try:
             return self._model.model_validate(result, strict=False, context=context)

--- a/tests/test_extra_allow.py
+++ b/tests/test_extra_allow.py
@@ -1,0 +1,85 @@
+from pydantic import ValidationError
+from pydantic_xml import BaseXmlModel, attr, element
+
+import pytest
+
+from tests.helpers import assert_xml_equal
+
+
+def test_extra_attributes_ignored():
+    class TestModel(BaseXmlModel, tag='model', extra='ignore'):
+        prop1: str = attr()
+        data: str
+
+    xml = '''
+    <model prop1="p1" prop2="p2">text</model>
+    '''
+
+    actual_obj = TestModel.from_xml(xml)
+    assert actual_obj.model_extra is None
+
+
+def test_extra_attributes_forbidden():
+    class TestModel(BaseXmlModel, tag='model', extra='forbid'):
+        prop1: str = attr()
+        data: str
+
+    xml = '''
+    <model prop1="p1" prop2="p2">text</model>
+    '''
+
+    with pytest.raises(ValidationError):
+        _ = TestModel.from_xml(xml)
+
+
+def test_extra_attributes():
+    class TestModel(BaseXmlModel, tag='model', extra='allow'):
+        prop1: str = attr()
+        data: str
+
+    xml = '''
+    <model prop1="p1" prop2="p2">text</model>
+    '''
+
+    actual_obj = TestModel.from_xml(xml)
+    assert "p2" == actual_obj.model_extra["prop2"]
+
+
+def test_extra_elements():
+
+    class TestModelChild(BaseXmlModel, tag="child"):
+        data: str
+
+    class TestModel(BaseXmlModel, tag='model', extra='allow'):
+        child: TestModelChild
+
+    xml = '''
+    <model prop1="p1" prop2="p2">
+        <child>hello world!</child>
+        <extra_child>hi again...</extra_child>
+    </model>
+    '''
+
+    actual_obj = TestModel.from_xml(xml)
+    assert "hello world!" == actual_obj.child.data
+    assert "extra_child" in actual_obj.model_extra
+
+
+def test_extra_save():
+
+    class TestModelChild(BaseXmlModel, tag="child"):
+        data: str
+
+    class TestModel(BaseXmlModel, tag='model', extra='allow'):
+        child: TestModelChild
+
+    xml = '''
+    <model prop1="p1" prop2="p2">
+        <child>hello world!</child>
+        <extra_child>hi again...</extra_child>
+    </model>
+    '''
+
+    actual_obj = TestModel.from_xml(xml)
+    actual_xml = actual_obj.to_xml()
+    assert_xml_equal(actual_xml, xml)

--- a/tests/test_extra_allow.py
+++ b/tests/test_extra_allow.py
@@ -42,43 +42,62 @@ def test_extra_attributes():
     '''
 
     actual_obj = TestModel.from_xml(xml)
-    assert "p2" == actual_obj.model_extra["prop2"]
+    assert 'p2' == actual_obj.model_extra['prop2']
 
 
 def test_extra_elements():
 
-    class TestModelChild(BaseXmlModel, tag="child"):
+    class TestModelChild(BaseXmlModel, tag='child'):
         data: str
 
     class TestModel(BaseXmlModel, tag='model', extra='allow'):
         child: TestModelChild
 
     xml = '''
-    <model prop1="p1" prop2="p2">
+    <model>
         <child>hello world!</child>
         <extra_child>hi again...</extra_child>
+        <extra_nested>
+            <extra_sub>1</extra_sub>
+            <extra_sub>2</extra_sub>
+            <extra_sub>3</extra_sub>
+            <extra_subsub>
+                <extra_subsubsub>3.14</extra_subsubsub>
+            </extra_subsub>
+        </extra_nested>
     </model>
     '''
 
     actual_obj = TestModel.from_xml(xml)
-    assert "hello world!" == actual_obj.child.data
-    assert "extra_child" in actual_obj.model_extra
+    assert 'hello world!' == actual_obj.child.data
+    assert 'extra_child' in actual_obj.model_extra
+    assert 'extra_nested' in actual_obj.model_extra
 
 
 def test_extra_save():
 
-    class TestModelChild(BaseXmlModel, tag="child"):
+    class TestModelChild(BaseXmlModel, tag='child'):
         data: str
 
     class TestModel(BaseXmlModel, tag='model', extra='allow'):
+        prop1: str = attr()
         child: TestModelChild
 
     xml = '''
-    <model prop1="p1" prop2="p2">
+    <model prop1="p1" prop2="p2" prop3="p3">
         <child>hello world!</child>
-        <extra_child>hi again...</extra_child>
     </model>
     '''
+    # TODO: Re-saving for children isn't working yet
+    # <extra_child>hi again...</extra_child>
+    # <extra_nested>
+    #     <extra_sub>1</extra_sub>
+    #     <extra_sub>2</extra_sub>
+    #     <extra_sub>3</extra_sub>
+    #     <extra_subsub>
+    #         <extra_subsubsub>3.14</extra_subsubsub>
+    #     </extra_subsub>
+    # </extra_nested>
 
     actual_obj = TestModel.from_xml(xml)
     actual_xml = actual_obj.to_xml()

--- a/tests/test_extra_allow.py
+++ b/tests/test_extra_allow.py
@@ -1,5 +1,6 @@
 from pydantic import ValidationError
 from pydantic_xml import BaseXmlModel, attr, element
+from pydantic_xml.element.native import ElementT
 
 import pytest
 
@@ -74,6 +75,30 @@ def test_extra_elements():
     assert 'extra_nested' in actual_obj.model_extra
 
 
+def test_raw_save():
+    # Just for debugging!!!
+
+    class TestModel(BaseXmlModel, tag='model', arbitrary_types_allowed=True):
+        extra_nested: ElementT = element()
+
+    xml = '''
+    <model>
+        <extra_nested>
+            <extra_sub>1</extra_sub>
+            <extra_sub>2</extra_sub>
+            <extra_sub>3</extra_sub>
+            <extra_subsub subprop="x">
+                <extra_subsubsub>3.14</extra_subsubsub>
+            </extra_subsub>
+        </extra_nested>
+    </model>
+    '''
+
+    actual_obj = TestModel.from_xml(xml)
+    actual_xml = actual_obj.to_xml()
+    assert_xml_equal(actual_xml, xml)
+
+
 def test_extra_save():
 
     class TestModelChild(BaseXmlModel, tag='child'):
@@ -86,18 +111,17 @@ def test_extra_save():
     xml = '''
     <model prop1="p1" prop2="p2" prop3="p3">
         <child>hello world!</child>
+        <extra_child>hi again...</extra_child>
+        <extra_nested>
+            <extra_sub>1</extra_sub>
+            <extra_sub>2</extra_sub>
+            <extra_sub>3</extra_sub>
+            <extra_subsub subprop="x">
+                <extra_subsubsub>3.14</extra_subsubsub>
+            </extra_subsub>
+        </extra_nested>
     </model>
     '''
-    # TODO: Re-saving for children isn't working yet
-    # <extra_child>hi again...</extra_child>
-    # <extra_nested>
-    #     <extra_sub>1</extra_sub>
-    #     <extra_sub>2</extra_sub>
-    #     <extra_sub>3</extra_sub>
-    #     <extra_subsub>
-    #         <extra_subsubsub>3.14</extra_subsubsub>
-    #     </extra_subsub>
-    # </extra_nested>
 
     actual_obj = TestModel.from_xml(xml)
     actual_xml = actual_obj.to_xml()

--- a/tests/test_extra_allow.py
+++ b/tests/test_extra_allow.py
@@ -126,3 +126,23 @@ def test_extra_save():
     actual_obj = TestModel.from_xml(xml)
     actual_xml = actual_obj.to_xml()
     assert_xml_equal(actual_xml, xml)
+
+
+def test_extra_save_order():
+
+    class TestModelChild(BaseXmlModel, tag='child'):
+        data: str
+
+    class TestModel(BaseXmlModel, tag='model', extra='allow', search_mode='ordered'):
+        child: TestModelChild
+
+    xml = '''
+    <model>
+        <other_child>Hi there</other_child>
+        <child>Hello world!</child>
+    </model>
+    '''
+
+    actual_obj = TestModel.from_xml(xml)
+    actual_xml = actual_obj.to_xml()
+    assert_xml_equal(actual_xml, xml)


### PR DESCRIPTION
Should resolve #304 
- #304 

`pydantic-xml` doesn't really honor `extra="allow"`, it only does `extra="ignore'`.

I would love to see behavior like in `pydantic` itself, see for example this test: https://github.com/pydantic/pydantic/blob/26da044ff35a7d9b7b26c798b8d3c44457468005/tests/test_main.py#L267

So in `pydantic` you can do something like this:
```python
    class Model(BaseModel):
        model_config = ConfigDict(extra='allow')
        a: float

    m = Model(a='10.2', b=12)
    assert m.model_extra == {'b': 12}
    m.c = 42
    assert m.model_dump() == {'a': 10.2, 'b': 12, 'c': 42}
```

Here for XML we could do the same, where we store attributes and extra child elements also under `.model_extra`. Attributes we could all load as string, the elements we could store as [raw XML](https://pydantic-xml.readthedocs.io/en/latest/pages/data-binding/raw.html).