### PR TITLE
Allow unions of unions

### DIFF
--- a/pydantic_xml/serializers/factories/union.py
+++ b/pydantic_xml/serializers/factories/union.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import pydantic as pd
@@ -16,8 +17,7 @@ class PrimitiveTypeSerializer(Serializer):
     def from_core_schema(cls, schema: pcs.UnionSchema, ctx: Serializer.Context) -> 'PrimitiveTypeSerializer':
         computed = ctx.field_computed
         inner_serializers: List[Serializer] = []
-        choice_schemas = _flatten_choice_schemas(schema['choices'])
-        for choice_schema in choice_schemas:
+        for choice_schema in schema['choices']:
             if isinstance(choice_schema, tuple):
                 choice_schema, label = choice_schema
 
@@ -69,8 +69,7 @@ class ModelSerializer(Serializer):
         model_name = ctx.model_name
         computed = ctx.field_computed
         inner_serializers: List[ModelProxySerializer] = []
-        choice_schemas = _flatten_choice_schemas(schema['choices'])
-        for choice_schema in choice_schemas:
+        for choice_schema in schema['choices']:
             if isinstance(choice_schema, tuple):
                 choice_schema, label = choice_schema
 
@@ -145,8 +144,8 @@ class ModelSerializer(Serializer):
 
 def from_core_schema(schema: pcs.UnionSchema, ctx: Serializer.Context) -> Serializer:
     choice_families: Set[SchemaTypeFamily] = set()
-    choice_schemas = _flatten_choice_schemas(schema['choices'])
-    for choice_schema in choice_schemas:
+    flattened_schema = _flatten_choice_schemas(deepcopy(schema), ctx)
+    for choice_schema in flattened_schema['choices']:
         if isinstance(choice_schema, tuple):
             choice_schema, label = choice_schema
 
@@ -166,30 +165,35 @@ def from_core_schema(schema: pcs.UnionSchema, ctx: Serializer.Context) -> Serial
 
     choice_family = choice_families.pop()
     if choice_family is SchemaTypeFamily.MODEL:
-        return ModelSerializer.from_core_schema(schema, ctx)
+        return ModelSerializer.from_core_schema(flattened_schema, ctx)
     elif choice_family is SchemaTypeFamily.PRIMITIVE:
-        return PrimitiveTypeSerializer.from_core_schema(schema, ctx)
+        return PrimitiveTypeSerializer.from_core_schema(flattened_schema, ctx)
     else:
         raise AssertionError("unreachable")
 
 
-def _flatten_choice_schemas(choice_schemas):
+def _flatten_choice_schemas(schema: pcs.UnionSchema, ctx: Serializer.Context) -> pcs.UnionSchema:
     """
     Flatten nested union choice_schemas into their components, leave others as they are
     """
-    schemas = choice_schemas[:]
+    choice_schemas = schema['choices']
     flattened_schemas = []
     seen_refs = set()
-    while schemas:
-        choice_schema = original_schema = schemas.pop()
+    while choice_schemas:
+        choice_schema = original_schema = choice_schemas.pop()
         if isinstance(choice_schema, tuple):
             choice_schema, label = choice_schema
-        if 'ref' in choice_schema:
-            if choice_schema['ref'] in seen_refs:
-                continue
-            seen_refs.add(choice_schema['ref'])
+        ref = choice_schema.get('schema_ref', choice_schema.get('ref'))
+        if ref in seen_refs:
+            continue
+        if ref:
+            seen_refs.add(ref)
+
+        if choice_schema['type'] == 'definition-ref':
+            choice_schema = ctx.definitions.get(choice_schema['schema_ref'])
         if choice_schema['type'] == 'union':
-            schemas.extend(choice_schema['choices'])
+            choice_schemas.extend(choice_schema['choices'])
         else:
             flattened_schemas.append(original_schema)
-    return flattened_schemas
+    schema['choices'] = flattened_schemas
+    return schema

--- a/pydantic_xml/serializers/factories/union.py
+++ b/pydantic_xml/serializers/factories/union.py
@@ -16,7 +16,8 @@ class PrimitiveTypeSerializer(Serializer):
     def from_core_schema(cls, schema: pcs.UnionSchema, ctx: Serializer.Context) -> 'PrimitiveTypeSerializer':
         computed = ctx.field_computed
         inner_serializers: List[Serializer] = []
-        for choice_schema in schema['choices']:
+        choice_schemas = _flatten_choice_schemas(schema['choices'])
+        for choice_schema in choice_schemas:
             if isinstance(choice_schema, tuple):
                 choice_schema, label = choice_schema
 
@@ -68,7 +69,8 @@ class ModelSerializer(Serializer):
         model_name = ctx.model_name
         computed = ctx.field_computed
         inner_serializers: List[ModelProxySerializer] = []
-        for choice_schema in schema['choices']:
+        choice_schemas = _flatten_choice_schemas(schema['choices'])
+        for choice_schema in choice_schemas:
             if isinstance(choice_schema, tuple):
                 choice_schema, label = choice_schema
 
@@ -143,7 +145,8 @@ class ModelSerializer(Serializer):
 
 def from_core_schema(schema: pcs.UnionSchema, ctx: Serializer.Context) -> Serializer:
     choice_families: Set[SchemaTypeFamily] = set()
-    for choice_schema in schema['choices']:
+    choice_schemas = _flatten_choice_schemas(schema['choices'])
+    for choice_schema in choice_schemas:
         if isinstance(choice_schema, tuple):
             choice_schema, label = choice_schema
 
@@ -168,3 +171,25 @@ def from_core_schema(schema: pcs.UnionSchema, ctx: Serializer.Context) -> Serial
         return PrimitiveTypeSerializer.from_core_schema(schema, ctx)
     else:
         raise AssertionError("unreachable")
+
+
+def _flatten_choice_schemas(choice_schemas):
+    """
+    Flatten nested union choice_schemas into their components, leave others as they are
+    """
+    schemas = choice_schemas[:]
+    flattened_schemas = []
+    seen_refs = set()
+    while schemas:
+        choice_schema = original_schema = schemas.pop()
+        if isinstance(choice_schema, tuple):
+            choice_schema, label = choice_schema
+        if 'ref' in choice_schema:
+            if choice_schema['ref'] in seen_refs:
+                continue
+            seen_refs.add(choice_schema['ref'])
+        if choice_schema['type'] == 'union':
+            schemas.extend(choice_schema['choices'])
+        else:
+            flattened_schemas.append(original_schema)
+    return flattened_schemas

--- a/tests/test_unions.py
+++ b/tests/test_unions.py
@@ -460,10 +460,11 @@ type Literals2 = Literal[5, 6]
 type Literals3 = Literal[0]
 type LiteralUnion1 = Literals1 | Literals2
 type LiteralUnion2 = LiteralUnion1 | Literals3
+type LiteralUnion3 = LiteralUnion2 | LiteralUnion1
 
 def test_nested_primitive_union():
     class Model(BaseXmlModel, tag='model'):
-        element1: Annotated[LiteralUnion2, BeforeValidator(int)] = element(tag='testLiteral')
+        element1: Annotated[LiteralUnion3, BeforeValidator(int)] = element(tag='testLiteral')
 
     xml = '''
     <model>

--- a/tests/test_unions.py
+++ b/tests/test_unions.py
@@ -1,9 +1,9 @@
 import sys
-from typing import List, Literal, Tuple, Union
+from typing import List, Literal, Tuple, Union, Annotated
 
 import pytest
 from helpers import assert_xml_equal
-from pydantic import Field
+from pydantic import Field, BeforeValidator
 
 from pydantic_xml import BaseXmlModel, RootXmlModel, attr, element
 
@@ -453,3 +453,76 @@ def test_union_snapshot():
 
     actual_xml = actual_obj.to_xml()
     assert_xml_equal(actual_xml, xml)
+
+
+type Literals1 = Literal[1, 2]
+type Literals2 = Literal[5, 6]
+type Literals3 = Literal[0]
+type LiteralUnion1 = Literals1 | Literals2
+type LiteralUnion2 = LiteralUnion1 | Literals3
+
+def test_nested_primitive_union():
+    class Model(BaseXmlModel, tag='model'):
+        element1: Annotated[LiteralUnion2, BeforeValidator(int)] = element(tag='testLiteral')
+
+    xml = '''
+    <model>
+        <testLiteral>5</testLiteral>
+    </model>
+    '''
+
+    actual = Model.from_xml(xml)
+    expected = Model(element1=5)
+    assert actual == expected
+
+    actual_xml = actual.to_xml()
+    assert_xml_equal(actual_xml, xml)
+
+
+class UnionTestModel1(BaseXmlModel, tag='model1'):
+    element1: int = element(tag='element1')
+
+class UnionTestModel2(BaseXmlModel, tag='model2'):
+    element2: str = element(tag='element2')
+
+type UnionTestModelUnion = UnionTestModel1 | UnionTestModel2
+
+def test_nested_model_union():
+    class UnionTestModel3(BaseXmlModel, tag='model3'):
+        element3: str = element(tag='element3')
+
+    class TopLevelModel(BaseXmlModel, tag='topLevel'):
+        top_element1: UnionTestModel3 | UnionTestModelUnion = element()
+
+    xml_1 = """
+    <topLevel>
+        <model1><element1>1</element1></model1>
+    </topLevel>
+    """
+    actual_1 = TopLevelModel.from_xml(xml_1)
+    expected_1 = TopLevelModel(top_element1=UnionTestModel1(element1=1))
+    assert actual_1 == expected_1
+    actual_1_xml = actual_1.to_xml()
+    assert_xml_equal(actual_1_xml, xml_1)
+
+    xml_2 = """
+    <topLevel>
+        <model2><element2>element 2</element2></model2>
+    </topLevel>
+    """
+    actual_2 = TopLevelModel.from_xml(xml_2)
+    expected_2 = TopLevelModel(top_element1=UnionTestModel2(element2='element 2'))
+    assert actual_2 == expected_2
+    actual_2_xml = actual_2.to_xml()
+    assert_xml_equal(actual_2_xml, xml_2)
+
+    xml_3 = """
+    <topLevel>
+        <model3><element3>element 3</element3></model3>
+    </topLevel>
+    """
+    actual_3 = TopLevelModel.from_xml(xml_3)
+    expected_3 = TopLevelModel(top_element1=UnionTestModel3(element3='element 3'))
+    assert actual_3 == expected_3
+    actual_3_xml = actual_3.to_xml()
+    assert_xml_equal(actual_3_xml, xml_3)


### PR DESCRIPTION
The checks on union choices do not allow for unions that contain other unions, even if those unions when flattened would still be all-primitive or all-model. For example in our project we have a set of response codes in an XML schema we are modeling using this library:
```py
type PermissionErrors = Literal[-4, -5]
type ServerErrors = Literal[-10, -11]
type CommonCodes = PermissionErrors | ServerErrors
type Request1ErrorCodes = Literal[-1, -2]
type Request1SuccessCodes = Literal[10, 11]
type Request1Codes = CommonCodes | Request1ErrorCodes | Request1SuccessCodes
```

Base Pydantic handles a field of type `Request1Codes` fine, but pydantic-xml does not:
```
================================================= short test summary info =================================================
FAILED tests/test_unions.py::test_nested_primitive_union - pydantic_xml.errors.ModelFieldError: Model.element1 field type error: union must be of primitive or model type
FAILED tests/test_unions.py::test_nested_model_union - pydantic_xml.errors.ModelFieldError: TopLevelModel.top_element1 field type error: union must be of primitive or model ...
============================================== 2 failed, 18 passed in 0.41s ===============================================
```
I modifed `union.py` to flatten union choices down when they consist of other unions so that the check on whether the union is not a mix of primitives and models still happens, but it no longer rejects a union that contains another union.

For anyone else running into this, a workaround is just to manually flatten your unions, ie the example above becomes:
```py
type PermissionErrors = Literal[-4, -5]
type ServerErrors = Literal[-10, -11]
type Request1ErrorCodes = Literal[-1, -2]
type Request1SuccessCodes = Literal[10, 11]
type Request1Codes = PermissionErrors | ServerErrors | Request1ErrorCodes | Request1SuccessCodes
```
but this has the downside of requiring duplication (for us `CommonCodes` is quite a bit larger and reused extensively) and not exactly matching your schema, plus not everyone has control over the types they are modeling.