### PR TITLE
hide_input_in_errors model config flag

### DIFF
--- a/pydantic_xml/serializers/factories/heterogeneous.py
+++ b/pydantic_xml/serializers/factories/heterogeneous.py
@@ -18,12 +18,19 @@ class ElementSerializer(Serializer):
         for item_schema in schema['items_schema']:
             inner_serializers.append(Serializer.parse_core_schema(item_schema, ctx))
 
-        return cls(model_name, computed, tuple(inner_serializers))
+        return cls(model_name, computed, tuple(inner_serializers), ctx.hide_input_in_errors)
 
-    def __init__(self, model_name: str, computed: bool, inner_serializers: Tuple[Serializer, ...]):
+    def __init__(
+            self,
+            model_name: str,
+            computed: bool,
+            inner_serializers: Tuple[Serializer, ...],
+            hide_input_in_errors: bool,
+    ):
         self._model_name = model_name
         self._computed = computed
         self._inner_serializers = inner_serializers
+        self._hide_input_in_errors = hide_input_in_errors
 
     def serialize(
             self,
@@ -74,7 +81,11 @@ class ElementSerializer(Serializer):
                 item_errors[idx] = err
 
         if item_errors:
-            raise utils.into_validation_error(title=self._model_name, errors_map=item_errors)
+            raise utils.into_validation_error(
+                title=self._model_name,
+                errors_map=item_errors,
+                hide_input=self._hide_input_in_errors,
+            )
 
         if all((value is None for value in result)):
             return None

--- a/pydantic_xml/serializers/factories/homogeneous.py
+++ b/pydantic_xml/serializers/factories/homogeneous.py
@@ -30,12 +30,13 @@ class ElementSerializer(Serializer):
 
         inner_serializer = Serializer.parse_core_schema(items_schema, ctx)
 
-        return cls(model_name, computed, inner_serializer)
+        return cls(model_name, computed, inner_serializer, ctx.hide_input_in_errors)
 
-    def __init__(self, model_name: str, computed: bool, inner_serializer: Serializer):
+    def __init__(self, model_name: str, computed: bool, inner_serializer: Serializer, hide_input_in_errors: bool):
         self._model_name = model_name
         self._computed = computed
         self._inner_serializer = inner_serializer
+        self._hide_input_in_errors = hide_input_in_errors
 
     def serialize(
             self,
@@ -91,7 +92,11 @@ class ElementSerializer(Serializer):
                 result.append(value)
 
         if item_errors:
-            raise utils.into_validation_error(title=self._model_name, errors_map=item_errors)
+            raise utils.into_validation_error(
+                title=self._model_name,
+                errors_map=item_errors,
+                hide_input=self._hide_input_in_errors,
+            )
 
         return result or None
 

--- a/pydantic_xml/serializers/factories/model.py
+++ b/pydantic_xml/serializers/factories/model.py
@@ -29,7 +29,7 @@ class BaseModelSerializer(Serializer, abc.ABC):
     def nsmap(self) -> Optional[NsMap]: ...
 
     @classmethod
-    def _check_extra(cls, error_title: str, element: XmlElementReader) -> None:
+    def _check_extra(cls, error_title: str, element: XmlElementReader, hide_input_in_errors: bool) -> None:
         line_errors: List[pdc.InitErrorDetails] = []
 
         for path, attr, value in element.get_unbound():
@@ -49,7 +49,11 @@ class BaseModelSerializer(Serializer, abc.ABC):
             )
 
         if line_errors:
-            raise pd.ValidationError.from_exception_data(title=error_title, line_errors=line_errors)
+            raise pd.ValidationError.from_exception_data(
+                title=error_title,
+                line_errors=line_errors,
+                hide_input=hide_input_in_errors,
+            )
 
 
 class ModelSerializer(BaseModelSerializer):
@@ -64,6 +68,8 @@ class ModelSerializer(BaseModelSerializer):
         assert issubclass(model_cls, pxml.BaseXmlModel), "model class must be a BaseXmlModel subclass"
         assert fields_schema['type'] == 'model-fields', f"unexpected schema type: {fields_schema['type']}"
         fields_schema = typing.cast(pcs.ModelFieldsSchema, fields_schema)
+
+        hide_input_in_errors = model_cls.model_config.get('hide_input_in_errors', ctx.hide_input_in_errors)
 
         entity_info: Optional[XmlEntityInfoP]
         fields_serialization_exclude: Set[str] = set()
@@ -83,6 +89,7 @@ class ModelSerializer(BaseModelSerializer):
                 field_name=field_name,
                 field_alias=field_alias,
                 entity_info=extract_field_xml_entity_info(field_info),
+                hide_input_in_errors=hide_input_in_errors,
             )
             fields_serializers[field_name] = Serializer.parse_core_schema(model_field['schema'], field_ctx)
 
@@ -101,6 +108,7 @@ class ModelSerializer(BaseModelSerializer):
                 field_alias=field_alias,
                 field_computed=True,
                 entity_info=entity_info,
+                hide_input_in_errors=hide_input_in_errors,
             )
             fields_serializers[field_name] = Serializer.parse_core_schema(model_field['return_schema'], field_ctx)
 
@@ -111,6 +119,7 @@ class ModelSerializer(BaseModelSerializer):
         return cls(
             model_cls, name, ns, nsmap,
             fields_serializers, fields_validation_aliases, fields_serialization_exclude,
+            hide_input_in_errors,
         )
 
     def __init__(
@@ -122,6 +131,7 @@ class ModelSerializer(BaseModelSerializer):
             field_serializers: Dict[str, Serializer],
             fields_validation_aliases: Dict[str, str],
             fields_serialization_exclude: Set[str],
+            hide_input_in_errors: bool,
     ):
 
         self._model = model
@@ -130,6 +140,7 @@ class ModelSerializer(BaseModelSerializer):
         self._nsmap = nsmap
         self._fields_validation_aliases = fields_validation_aliases
         self._fields_serialization_exclude = fields_serialization_exclude
+        self._hide_input_in_errors = hide_input_in_errors
 
     @property
     def model(self) -> Type['pxml.BaseXmlModel']:
@@ -210,15 +221,19 @@ class ModelSerializer(BaseModelSerializer):
                 field_errors[field_name] = err
 
         if field_errors:
-            raise utils.into_validation_error(title=self._model.__name__, errors_map=field_errors)
+            raise utils.into_validation_error(
+                title=self._model.__name__,
+                errors_map=field_errors,
+                hide_input=self._hide_input_in_errors,
+            )
 
         if self._model.model_config.get('extra', 'ignore') == 'forbid':
-            self._check_extra(self._model.__name__, element)
+            self._check_extra(self._model.__name__, element, self._hide_input_in_errors)
 
         try:
             return self._model.model_validate(result, strict=False, context=context)
         except pd.ValidationError as err:
-            raise utils.set_validation_error_sourceline(err, sourcemap)
+            raise utils.set_validation_error_sourceline(err, sourcemap, hide_input=self._hide_input_in_errors)
 
 
 class RootModelSerializer(BaseModelSerializer):
@@ -229,10 +244,13 @@ class RootModelSerializer(BaseModelSerializer):
 
         assert issubclass(model_cls, pxml.BaseXmlModel), "model class must be a BaseXmlModel subclass"
 
+        hide_input_in_errors = model_cls.model_config.get('hide_input_in_errors', ctx.hide_input_in_errors)
+
         field_info = model_cls.model_fields['root']
         field_ctx = ctx.child(
             field_name=None,
             entity_info=extract_field_xml_entity_info(field_info),
+            hide_input_in_errors=hide_input_in_errors,
         )
         root_serializer = Serializer.parse_core_schema(root_schema, field_ctx)
 
@@ -240,7 +258,7 @@ class RootModelSerializer(BaseModelSerializer):
         ns = model_cls.__xml_ns__
         nsmap = model_cls.__xml_nsmap__
 
-        return cls(model_cls, name, ns, nsmap, root_serializer)
+        return cls(model_cls, name, ns, nsmap, root_serializer, hide_input_in_errors)
 
     def __init__(
             self,
@@ -249,12 +267,14 @@ class RootModelSerializer(BaseModelSerializer):
             ns: Optional[str],
             nsmap: Optional[NsMap],
             root_serializer: Serializer,
+            hide_input_in_errors: bool,
     ):
 
         self._model = model
         self._root_serializer = root_serializer
         self._element_name = QName.from_alias(tag=name, ns=ns, nsmap=nsmap).uri
         self._nsmap = nsmap
+        self._hide_input_in_errors = hide_input_in_errors
 
     @property
     def model(self) -> Type['pxml.BaseXmlModel']:
@@ -312,15 +332,19 @@ class RootModelSerializer(BaseModelSerializer):
             if result is None:
                 result = pdc.PydanticUndefined
         except pd.ValidationError as err:
-            raise utils.into_validation_error(title=self._model.__name__, errors_map={None: err})
+            raise utils.into_validation_error(
+                title=self._model.__name__,
+                errors_map={None: err},
+                hide_input=self._hide_input_in_errors,
+            )
 
         if self._model.model_config.get('extra', 'ignore') == 'forbid':
-            self._check_extra(self._model.__name__, element)
+            self._check_extra(self._model.__name__, element, self._hide_input_in_errors)
 
         try:
             return self._model.model_validate(result, strict=False, context=context)
         except pd.ValidationError as err:
-            raise utils.set_validation_error_sourceline(err, sourcemap)
+            raise utils.set_validation_error_sourceline(err, sourcemap, hide_input=self._hide_input_in_errors)
 
 
 class ModelProxySerializer(BaseModelSerializer):

--- a/pydantic_xml/serializers/factories/named_tuple.py
+++ b/pydantic_xml/serializers/factories/named_tuple.py
@@ -20,10 +20,18 @@ class ElementSerializer(Serializer):
             param_schema = argument_schema['schema']
             inner_serializers.append(Serializer.parse_core_schema(param_schema, ctx))
 
-        return cls(model_name, computed, tuple(inner_serializers))
+        return cls(model_name, computed, tuple(inner_serializers), ctx.hide_input_in_errors)
 
-    def __init__(self, model_name: str, computed: bool, inner_serializers: Tuple[Serializer, ...]):
-        self._inner_serializer = heterogeneous.ElementSerializer(model_name, computed, inner_serializers)
+    def __init__(
+            self,
+            model_name: str,
+            computed: bool,
+            inner_serializers: Tuple[Serializer, ...],
+            hide_input_in_errors: bool,
+    ):
+        self._inner_serializer = heterogeneous.ElementSerializer(
+            model_name, computed, inner_serializers, hide_input_in_errors,
+        )
 
     def serialize(
             self,

--- a/pydantic_xml/serializers/factories/union.py
+++ b/pydantic_xml/serializers/factories/union.py
@@ -79,12 +79,19 @@ class ModelSerializer(Serializer):
 
         assert len(inner_serializers) > 0, "union choice is not provided"
 
-        return cls(model_name, computed, tuple(inner_serializers))
+        return cls(model_name, computed, tuple(inner_serializers), ctx.hide_input_in_errors)
 
-    def __init__(self, model_name: str, computed: bool, inner_serializers: Tuple[ModelProxySerializer, ...]):
+    def __init__(
+            self,
+            model_name: str,
+            computed: bool,
+            inner_serializers: Tuple[ModelProxySerializer, ...],
+            hide_input_in_errors: bool,
+    ):
         self._model_name = model_name
         self._computed = computed
         self._inner_serializers = inner_serializers
+        self._hide_input_in_errors = hide_input_in_errors
 
     def serialize(
             self,
@@ -136,7 +143,9 @@ class ModelSerializer(Serializer):
 
         if union_errors:
             element.step_forward()
-            raise utils.into_validation_error(title=self._model_name, errors_map=union_errors)
+            raise utils.into_validation_error(
+                title=self._model_name, errors_map=union_errors, hide_input=self._hide_input_in_errors,
+            )
 
         return result
 

--- a/pydantic_xml/serializers/serializer.py
+++ b/pydantic_xml/serializers/serializer.py
@@ -110,6 +110,8 @@ class Serializer(abc.ABC):
         has_default: bool = False
         definitions: Dict[str, pcs.CoreSchema] = dc.field(default_factory=dict)
 
+        hide_input_in_errors: bool = False
+
         parent_ctx: Optional['Serializer.Context'] = None
 
         @property

--- a/pydantic_xml/utils.py
+++ b/pydantic_xml/utils.py
@@ -108,6 +108,7 @@ def select_ns(*nss: Optional[str]) -> Optional[str]:
 def into_validation_error(
         title: str,
         errors_map: Dict[Union[None, str, int], pd.ValidationError],
+        hide_input: bool,
 ) -> pd.ValidationError:
     line_errors: List[pdc.InitErrorDetails] = []
     for location in list(errors_map):
@@ -125,10 +126,15 @@ def into_validation_error(
         title=title,
         input_type='json',
         line_errors=line_errors,
+        hide_input=hide_input,
     )
 
 
-def set_validation_error_sourceline(err: pd.ValidationError, sourcemap: Dict[Location, int]) -> pd.ValidationError:
+def set_validation_error_sourceline(
+        err: pd.ValidationError,
+        sourcemap: Dict[Location, int],
+        hide_input: bool,
+) -> pd.ValidationError:
     line_errors: List[pdc.InitErrorDetails] = []
     for error in err.errors():
         loc, sourceline = error['loc'], -1
@@ -150,4 +156,5 @@ def set_validation_error_sourceline(err: pd.ValidationError, sourcemap: Dict[Loc
     return pd.ValidationError.from_exception_data(
         err.title,
         line_errors=line_errors,
+        hide_input=hide_input,
     )

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,3 +1,4 @@
+import re
 import sys
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -412,3 +413,31 @@ def test_get_type_hints():
 
     hints = get_type_hints(TestModel)
     assert isinstance(hints, dict)
+
+
+@pytest.mark.parametrize('model_hide_input, input_in_error_hidden', [(None, False), (False, False), (True, True)])
+def test_error_input_hiding(model_hide_input: bool, input_in_error_hidden: bool):
+    class TestSubModel(BaseXmlModel):
+        val: int
+
+    class TestModel(BaseXmlModel, tag="model"):
+        if model_hide_input is not None:
+            model_config = pd.ConfigDict(hide_input_in_errors=model_hide_input)
+
+        submodel: TestSubModel
+
+    xml = '''
+        <model>
+            <submodel>a</submodel>
+        </model>
+    '''
+
+    with pytest.raises(pd.ValidationError) as e:
+        TestModel.from_xml(xml)
+
+    error_str = str(e.value)
+    error_value_input = re.search("input_value='a'", error_str)
+    if input_in_error_hidden:
+        assert not error_value_input, error_str
+    else:
+        assert error_value_input, error_str


### PR DESCRIPTION
- hide_input_in_errors model config flag support added.

fixes the [issue](https://github.com/dapper91/pydantic-xml/issues/307). 