### PR TITLE
Refactor XML namespace handling in BaseXmlModel and add test, resolve…

### DIFF
--- a/pydantic_xml/model.py
+++ b/pydantic_xml/model.py
@@ -193,8 +193,7 @@ class BaseXmlModel(BaseModel, __xml_abstract__=True, metaclass=XmlModelMeta):
             else getattr(cls, '__xml_search_mode__', SearchMode.STRICT)
 
         if parent_nsmap := getattr(cls, '__xml_nsmap__', None):
-            parent_nsmap.update(nsmap or {})
-            cls.__xml_nsmap__ = parent_nsmap
+            cls.__xml_nsmap__ = parent_nsmap | (nsmap or {})
         else:
             cls.__xml_nsmap__ = nsmap
 

--- a/tests/test_namespaces.py
+++ b/tests/test_namespaces.py
@@ -359,6 +359,47 @@ def test_model_inheritance_params_redefinition():
     assert_xml_equal(actual_xml, xml1)
 
 
+def test_subclass_nsmap_does_not_mutate_parent():
+    # defining a subclass with a different nsmap must not modify the parent's
+    # (or any shared module-level) namespace map.
+    nsmap_v1 = {"hq": "http://www.company.com/hq/v1", "pd": "http://www.company.com/prod"}
+    nsmap = {"hq": "http://www.company.com/hq", "pd": "http://www.company.com/prod"}
+    original_nsmap = dict(nsmap)
+
+    class Headquarters(BaseXmlModel, ns="hq", nsmap=nsmap):
+        country: str = element()
+        state: str = element()
+        city: str = element()
+
+    class HeadquartersV1(Headquarters, ns="hq", nsmap=nsmap_v1):
+        pass
+
+    class Company(BaseXmlModel, tag="Company", nsmap=nsmap):
+        trade_name: str = attr(name="trade-name")
+        headquarters: Headquarters
+
+    assert nsmap == original_nsmap, "parent nsmap must not be mutated by subclass definition"
+    assert Headquarters.__xml_nsmap__ == original_nsmap
+    assert HeadquartersV1.__xml_nsmap__ == {**original_nsmap, **nsmap_v1}
+
+    xml = """
+    <Company trade-name="Beboop" xmlns:pd="http://www.company.com/prod">
+        <hq:headquarters xmlns:hq="http://www.company.com/hq">
+            <hq:country>US</hq:country>
+            <hq:state>West Virginia</hq:state>
+            <hq:city>Almost Heaven</hq:city>
+        </hq:headquarters>
+    </Company>
+    """
+
+    actual_obj = Company.from_xml(xml)
+    expected_obj = Company(
+        trade_name="Beboop",
+        headquarters=Headquarters(country="US", state="West Virginia", city="Almost Heaven"),
+    )
+    assert actual_obj == expected_obj
+
+
 def test_submodel_namespaces_default_namespace_inheritance():
     class TestSubModel(BaseXmlModel, tag='submodel', ns='', nsmap={'': 'http://test2.org'}):
         attr1: int = attr()


### PR DESCRIPTION
resolves #315 

Regression was introduced in bb30d8b which replaced a simple inherit-by-reference with an in-place `parent_nsmap.update(nsmap or {})`. That mutates the parent class's (and, in issue #315, the module-level shared) nsmap dict.

This PR was developed with the assistance of Cursor. I've reviewed and verified the changes.