### PR TITLE
fix: parse PEP 440 pre-release versions in compat module

### DIFF
--- a/pydantic_xml/compat.py
+++ b/pydantic_xml/compat.py
@@ -3,14 +3,15 @@ pydantic compatibility module.
 """
 
 import pydantic as pd
+from packaging.version import Version
 from pydantic._internal._model_construction import ModelMetaclass  # noqa
 from pydantic.root_model import _RootModelMetaclass as RootModelMetaclass  # noqa
 
-PYDANTIC_VERSION = tuple(map(int, pd.__version__.partition('+')[0].split('.')))
+PYDANTIC_VERSION = Version(pd.__version__)
 
 
 def merge_field_infos(*field_infos: pd.fields.FieldInfo) -> pd.fields.FieldInfo:
-    if PYDANTIC_VERSION >= (2, 12, 0):
+    if PYDANTIC_VERSION >= Version('2.12.0'):
         return pd.fields.FieldInfo._construct(list(field_infos))
     else:
         return pd.fields.FieldInfo.merge_field_infos(*field_infos)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.8"
 lxml = {version = ">=4.9.0", optional = true}
+packaging = ">=21.0"
 pydantic = ">=2.6.0, !=2.10.0b1"
 pydantic-core = ">=2.15.0"
 


### PR DESCRIPTION
tuple(map(int, pd.__version__.partition('+')[0].split('.'))) raised ValueError on valid pre-release version strings such as '2.14.0a0' or '2.14.0.dev0', because int('0a0') fails.

Switch to packaging.version.Version, which handles the full PEP 440 grammar and gives correct ordering semantics for pre-release, dev, and post-release versions.

packaging is declared as a new dependency. It is already a transitive dependency in virtually all Python environments (via pip/setuptools), so the declaration only makes existing reality explicit.