### PR TITLE
fix: base model nsmap override bug fixed.

### DIFF
--- a/pydantic_xml/model.py
+++ b/pydantic_xml/model.py
@@ -193,8 +193,7 @@ class BaseXmlModel(BaseModel, __xml_abstract__=True, metaclass=XmlModelMeta):
             else getattr(cls, '__xml_search_mode__', SearchMode.STRICT)
 
         if parent_nsmap := getattr(cls, '__xml_nsmap__', None):
-            parent_nsmap.update(nsmap or {})
-            cls.__xml_nsmap__ = parent_nsmap
+            cls.__xml_nsmap__ = dict(parent_nsmap, **(nsmap or {}))
         else:
             cls.__xml_nsmap__ = nsmap
 

--- a/tests/test_namespaces.py
+++ b/tests/test_namespaces.py
@@ -314,12 +314,18 @@ def test_mapping_wrapper_namespace_inheritance():
 
 
 def test_model_inheritance():
-    class BaseTestModel(BaseXmlModel, tag='model', ns='tst', nsmap={'tst': 'http://test1.org'}):
+    base_nsmap = {'tst': 'http://test.org'}
+    nsmap = {'tst': 'http://test1.org'}
+
+    class BaseTestModel(BaseXmlModel, tag='model', ns='tst', nsmap=base_nsmap):
         attr1: int = attr()
         element1: str = element()
 
-    class TestModel(BaseTestModel):
+    class TestModel(BaseTestModel, nsmap=nsmap):
         pass
+
+    assert BaseTestModel.__xml_nsmap__ == base_nsmap
+    assert TestModel.__xml_nsmap__ == nsmap
 
     xml1 = '''
     <tst:model xmlns:tst="http://test1.org" attr1="1">


### PR DESCRIPTION
Parent nsmap is mutated by inherited classes. It must be copied before update.

fixes the https://github.com/dapper91/pydantic-xml/issues/315